### PR TITLE
Downgrades Node runtime requirements to version 8

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "10.16.3"
+          "node": "8.16.1"
         },
         "modules": "commonjs",
         "useBuiltIns": "entry",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "10"
   - "11"
   - "12"

--- a/build.js
+++ b/build.js
@@ -13,6 +13,9 @@ fs.readdirSync(parserFolder)
     const parser = peg.generate(source, {
       format: 'commonjs',
       output: 'source',
+      dependencies: {
+        "BigInt": "big-integer",
+      },
     })
     fs.writeFileSync(path.join(__dirname, `build/${name}.js`), parser)
   })

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/taozhi8833998/node-sql-parser#readme",
   "engines": {
-    "node": ">=10"
+    "node": ">=8"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
+    "big-integer": "^1.6.45",
     "has": "^1.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,6 +937,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.45:
+  version "1.6.45"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.45.tgz#1bf2fa1271bfd20d4c52c3d6c6f08cab8d91c77e"
+  integrity sha512-nmb9E7oEtVJ7SmSCH/DeJobXyuRmaofkpoQSimMFu3HKJ5MADtM825SPLhDuWhZ6TElLAQtgJbQmBZuHIRlZoA==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
It does not appear that a minimum engine version of Node 10 is required for execution.

A project that I am using this dependency in does not yet support Node 10, and it would simplify my build process greatly if the engine requirement was removed.

I've added the Node 8 version back to the Travis CI build to confirm that the runtime is valid.