### PR TITLE
support order by and limit in update and delete sql

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export interface Option {
 }
 export interface TableColumnAst {
   tableList: string[];
-  columnsList: string[];
+  columnList: string[];
   ast: AST[] | AST;
 }
 export interface From {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sql-parser",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "simple node sql parser",
   "main": "index.js",
   "types": "index.d.ts",

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1186,7 +1186,9 @@ update_stmt
     t:table_ref_list __
     KW_SET       __
     l:set_list   __
-    w:where_clause? {
+    w:where_clause? __
+    or:order_by_clause? __
+    lc:limit_clause? {
       if (t) t.forEach(tableInfo => {
         const { db, as, table } = tableInfo
         tableList.add(`update::${db}::${table}`)
@@ -1201,7 +1203,9 @@ update_stmt
           type: 'update',
           table: t,
           set: l,
-          where: w
+          where: w,
+          orderby: or,
+          limit: lc,
         }
       };
     }
@@ -1210,7 +1214,9 @@ delete_stmt
   = KW_DELETE    __
     t: table_ref_list? __
     f:from_clause __
-    w:where_clause? {
+    w:where_clause? __
+    or:order_by_clause? __
+    l:limit_clause? {
       if(f) f.forEach(info => {
         info.table && tableList.add(`delete::${info.db}::${info.table}`);
         columnList.add(`delete::${info.table}::(.*)`);
@@ -1231,7 +1237,9 @@ delete_stmt
           type: 'delete',
           table: t,
           from: f,
-          where: w
+          where: w,
+          orderby: or,
+          limit: l,
         }
       };
     }

--- a/src/delete.js
+++ b/src/delete.js
@@ -1,11 +1,12 @@
 import { columnsToSQL } from './column'
+import { exprToSQL, orderOrPartitionByToSQL } from './expr'
+import { limitToSQL } from './limit'
 import { tablesToSQL } from './tables'
-import { exprToSQL } from './expr'
 import { commonOptionConnector, hasVal } from './util'
 
 function deleteToSQL(stmt) {
   const clauses = ['DELETE']
-  const { columns, from, table, where } = stmt
+  const { columns, from, table, where, orderby, limit } = stmt
   const columnInfo = columnsToSQL(columns, from)
   clauses.push(columnInfo)
   if (Array.isArray(table)) {
@@ -13,6 +14,8 @@ function deleteToSQL(stmt) {
   }
   clauses.push(commonOptionConnector('FROM', tablesToSQL, from))
   clauses.push(commonOptionConnector('WHERE', exprToSQL, where))
+  clauses.push(orderOrPartitionByToSQL(orderby, 'order by'))
+  clauses.push(limitToSQL(limit))
   return clauses.filter(hasVal).join(' ')
 }
 

--- a/src/update.js
+++ b/src/update.js
@@ -1,5 +1,6 @@
 import { tablesToSQL } from './tables'
-import { exprToSQL } from './expr'
+import { exprToSQL, orderOrPartitionByToSQL } from './expr'
+import { limitToSQL } from './limit'
 import { hasVal, identifierToSql, commonOptionConnector, returningToSQL } from './util'
 
 /**
@@ -20,12 +21,14 @@ function setToSQL(sets) {
 }
 
 function updateToSQL(stmt) {
-  const { table, set, where, returning } = stmt
+  const { table, set, where, orderby, limit, returning } = stmt
   const clauses = [
     'UPDATE',
     tablesToSQL(table),
     commonOptionConnector('SET', setToSQL, set),
     commonOptionConnector('WHERE', exprToSQL, where),
+    orderOrPartitionByToSQL(orderby, 'order by'),
+    limitToSQL(limit),
     returningToSQL(returning),
   ]
   return clauses.filter(hasVal).join(' ')

--- a/test/delete.spec.js
+++ b/test/delete.spec.js
@@ -5,6 +5,11 @@ const { deleteToSQL } = require('../src/delete')
 describe('delete', () => {
     const parser = new Parser();
 
+    function getParsedSql(sql, opt) {
+      const ast = parser.astify(sql, opt);
+      return parser.sqlify(ast, opt);
+  }
+
     it('should parse baisc usage', () => {
       const { tableList, columnList, ast } = parser.parse('delete from a where id = 1');
       expect(tableList).to.eql(['delete::null::a']);
@@ -113,4 +118,11 @@ describe('delete', () => {
          }
       });
     });
+
+   it('should support order by and limit in delete sql', () => {
+      expect(getParsedSql('delete from t1 where id = 1 order by id')).to.be.equal('DELETE FROM `t1` WHERE `id` = 1 ORDER BY `id` ASC')
+      expect(getParsedSql('delete from t1 where id = 1 limit 10')).to.be.equal('DELETE FROM `t1` WHERE `id` = 1 LIMIT 10')
+      expect(getParsedSql('delete from t1 where id = 1 order by id limit 10')).to.be.equal('DELETE FROM `t1` WHERE `id` = 1 ORDER BY `id` ASC LIMIT 10')
+      expect(getParsedSql('delete from t1 order by id limit 10')).to.be.equal('DELETE FROM `t1` ORDER BY `id` ASC LIMIT 10')
+   })
 });

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -4,6 +4,11 @@ const Parser = require('../src/parser').default
 describe('update', () => {
     const parser = new Parser();
 
+    function getParsedSql(sql, opt) {
+      const ast = parser.astify(sql, opt);
+      return parser.sqlify(ast, opt);
+  }
+
     it('should parse baisc usage', () => {
       const { tableList, columnList, ast } = parser.parse('UPDATE a set id = 1');
       expect(tableList).to.eql(["update::null::a"]);
@@ -193,6 +198,13 @@ describe('update', () => {
         "value": 12
       }
     });
+  })
+
+  it('should support order by and limit in update sql', () => {
+    expect(getParsedSql('update a set id = 123 where age > 15 order by name')).to.be.equal('UPDATE `a` SET `id` = 123 WHERE `age` > 15 ORDER BY `name` ASC')
+    expect(getParsedSql('update a set id = 123 order by name')).to.be.equal('UPDATE `a` SET `id` = 123 ORDER BY `name` ASC')
+    expect(getParsedSql('update a set id = 123 limit 10')).to.be.equal('UPDATE `a` SET `id` = 123 LIMIT 10')
+    expect(getParsedSql('update a set id = 123 order by name limit 10')).to.be.equal('UPDATE `a` SET `id` = 123 ORDER BY `name` ASC LIMIT 10')
   })
 
   it('should support parse pg update returning', () => {


### PR DESCRIPTION
- support `order by` and `limit` in delete and update SQL in MySQL #372 
- fix #366 