### PR TITLE
fix postgres unique index on table creation

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -358,7 +358,7 @@ create_column_definition
     d:data_type __
     clc:column_constraint? __
     a:('AUTO_INCREMENT'i)? __
-    u:(('UNIQUE'i / 'PRIMARY'i)? __ 'KEY'i)? __
+    u:('UNIQUE'i / 'PRIMARY KEY'i)? __
     co:keyword_comment? __
     ca:collate_expr? __
     cf:column_format? __
@@ -371,7 +371,7 @@ create_column_definition
         nullable: clc && clc.nullable,
         default_val: clc && clc.default_val,
         auto_increment: a && a.toLowerCase(),
-        unique_or_primary: u && `${u[0].toLowerCase()} ${u[2].toLowerCase()}`,
+        unique_or_primary: u && u.toLowerCase(),
         comment: co,
         collate: ca,
         column_format: cf,

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -267,17 +267,21 @@ describe('create', () => {
     })
 
     describe('create table using pg', () => {
-      expect(getParsedSql(`CREATE TABLE foo (id uuid)`, { database: 'postgresql' })).to.equal('CREATE TABLE "foo" ("id" UUID)')
-      expect(getParsedSql(`CREATE TABLE accounts (
-        id UUID DEFAULT uuid_generate_v4() NOT NULL,
-        email TEXT NOT NULL,
-        password TEXT NOT NULL,
 
-        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-        updated_at TIMESTAMP NULL,
+      it ('supports basic things', () => {
+        expect(getParsedSql(`CREATE TABLE foo (id uuid)`, { database: 'postgresql' })).to.equal('CREATE TABLE "foo" ("id" UUID)')
+        expect(getParsedSql(`CREATE TABLE foo (value text unique)`, { database: 'postgresql' })).to.equal('CREATE TABLE "foo" ("value" TEXT UNIQUE)')
+        expect(getParsedSql(`CREATE TABLE accounts (
+          id UUID DEFAULT uuid_generate_v4() NOT NULL,
+          email TEXT NOT NULL,
+          password TEXT NOT NULL,
 
-        PRIMARY KEY (id)
-      );`, { database: 'postgresql' })).to.equal('CREATE TABLE "accounts" ("id" UUID NOT NULL DEFAULT uuid_generate_v4(), "email" TEXT NOT NULL, "password" TEXT NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT NOW(), "updated_at" TIMESTAMP NULL, PRIMARY KEY ("id"))')
+          created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMP NULL,
+
+          PRIMARY KEY (id)
+        );`, { database: 'postgresql' })).to.equal('CREATE TABLE "accounts" ("id" UUID NOT NULL DEFAULT uuid_generate_v4(), "email" TEXT NOT NULL, "password" TEXT NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT NOW(), "updated_at" TIMESTAMP NULL, PRIMARY KEY ("id"))');
+      })
 
       it('should support pg bool/boolean type', () => {
         expect(getParsedSql(`CREATE TABLE "foos"
@@ -436,7 +440,7 @@ describe('create', () => {
       expect(columnOrderListToSQL()).to.be.equal(undefined)
     })
   })
-  describe('throw error when create type is unknow', () => {
+  it('throw error when create type is unknow', () => {
     const ast = {
       type: 'create',
       keyword: 'unknow_create_type'
@@ -444,4 +448,3 @@ describe('create', () => {
     expect(parser.sqlify.bind(parser, ast)).to.throw(`unknow create resource ${ast.keyword}`)
   })
 })
-


### PR DESCRIPTION
If I am not mistaken, `create table test(value unique key)` is NOT a valid postgres syntax... `create table test(value unique)` should be better.

This pull requests fixes it, and also fixes two tests which were using `expect()` directly in `describe()` statements, (not in `it()`)