### PR TITLE
Remove duplicate identifier 'Parser'

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -126,19 +126,3 @@ export class Parser {
 
   columnList(sql: string, opt?: Option): string[];
 }
-
-export class Parser {
-  constructor();
-
-  parse(sql: string, opt?: Option): TableColumnAst;
-
-  astify(sql: string, opt?: Option): AST[] | AST;
-
-  sqlify(ast: AST[] | AST, opt?: Option): string;
-
-  whiteListCheck(sql: string, whiteList: string[], opt?: Option): Error | undefined;
-
-  tableList(sql: string, opt?: Option): string[];
-
-  columnList(sql: string, opt?: Option): string[];
-}


### PR DESCRIPTION
Hi. `node-sql-parser` very awesome package! always thanks.

Duplicate identifier `Parser` class found in `types.d.ts`.
I think it should be removed because the current build failed.

