### PR TITLE
Properly escape Postgres & TSQL column alias containing special characters

### DIFF
--- a/src/column.js
+++ b/src/column.js
@@ -3,6 +3,7 @@ import { exprToSQL } from './expr'
 import { tablesToSQL } from './tables'
 import {
   autoIncreatementToSQL,
+  columnIdentifierToSql,
   commonOptionConnector,
   commonTypeValue,
   commentToSQL,
@@ -113,7 +114,7 @@ function columnToSQL(column, isDual) {
   if (column.as !== null) {
     str = `${str} AS `
     if (column.as.match(/^[a-z_][0-9a-z_]*$/i)) str = `${str}${identifierToSql(column.as)}`
-    else str = `${str}\`${column.as}\``
+    else str = `${str}${columnIdentifierToSql(column.as)}`
   }
   return str
 }

--- a/src/util.js
+++ b/src/util.js
@@ -121,6 +121,23 @@ function topToSQL(opt) {
   return `${prefix} ${percent.toUpperCase()}`
 }
 
+function columnIdentifierToSql(ident) {
+  const { database } = getParserOpt()
+  if (!ident) return
+  switch (database && database.toLowerCase()) {
+    case 'postgresql':
+    case 'db2':
+      return `"${ident}"`
+    case 'transactsql':
+      return `[${ident}]`
+    case 'mysql':
+    case 'mariadb':
+    case 'bigquery':
+    default:
+      return `\`${ident}\``
+  }
+}
+
 function identifierToSql(ident, isDual) {
   const { database } = getParserOpt()
   if (isDual === true) return `'${ident}'`
@@ -281,7 +298,7 @@ export {
   arrayStructTypeToSQL, autoIncreatementToSQL,
   columnOrderListToSQL, commonKeywordArgsToSQL, commonOptionConnector,
   connector, commonTypeValue,commentToSQL, createBinaryExpr,
-  createValueExpr, DEFAULT_OPT, escape, literalToSQL,
+  createValueExpr, DEFAULT_OPT, escape, literalToSQL, columnIdentifierToSql,
   identifierToSql, onPartitionsToSQL, replaceParams, returningToSQL,
   hasVal, setParserOpt, toUpper, topToSQL, triggerEventToSQL,
 }

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1231,7 +1231,28 @@ describe('select', () => {
       const backSQL = parser.sqlify(ast, opt)
       expect(backSQL).to.equal('CREATE TABLE [test] ([id] BIGINT NOT NULL IDENTITY(1, 1) PRIMARY KEY)')
     })
+
+    it('should properly escape column aliases that contain special characters', () => {
+      const sql = `select column_name as [Column Name] from table_name`
+      const ast = parser.astify(sql, opt)
+      const backSQL = parser.sqlify(ast, opt)
+      expect(backSQL).to.equal('SELECT [column_name] AS [Column Name] FROM [table_name]')
+    })
   })
+
+  describe('postgreql', () => {
+    const opt = {
+      database: 'postgresql'
+    }
+    it('should properly escape column aliases that contain special characters', () => {
+      const sql = `select column_name as "Column Name" from table_name`
+      const ast = parser.astify(sql, opt)
+      const backSQL = parser.sqlify(ast, opt)
+      expect(backSQL).to.equal('SELECT "column_name" AS "Column Name" FROM "table_name"')
+    })
+  })
+
+
   describe('unknow type check', () => {
     it('should throw error', () => {
       const sql = 'SELECT * FROM a'


### PR DESCRIPTION
Currently, output Postgresql / TSQL column aliases that contain special characters are wrapped in backticks. This is not valid SQL for either of these dialects; in Postgres the alias should be wrapped in double quotes, in TSQL the alias should be wrapped in either square brackets or double quotes.

Example of current behavior:
```js
const { Parser } = require('node-sql-parser');
const parser = new Parser()

const sqlInput = 'SELECT column_name AS "Column Name" FROM "table_name" as "Table Alias"';
const ast = parser.astify(sqlInput, { database: 'postgresql' });
const sqlOutput = parser.sqlify(ast, { database: 'postgresql'});

console.log(sqlOutput); // SELECT "column_name" AS `Column Name` FROM "table_name" AS "Table Alias"
```

In this PR I added a new function specific to column alias formatting, as using the existing `identifierToSql` function seemed to be breaking for bigquery, at the very least.

I included DB2 in the "double-quote" escape block, as brief research suggests this to be correct ([source](https://www.ibm.com/support/knowledgecenter/en/SSEPEK_10.0.0/sqlref/src/tpc/db2z_delimitedidentifiers.html)). I've never used DB2, so please let me know if this is incorrect.

Example of new behavior:
```js
const { Parser } = require('node-sql-parser');
const parser = new Parser()

const sqlInput = 'SELECT column_name AS "Column Name" FROM "table_name" as "Table Alias"';
const ast = parser.astify(sqlInput, { database: 'postgresql' });
const sqlOutput = parser.sqlify(ast, { database: 'postgresql'});

console.log(sqlOutput); // SELECT "column_name" AS "Column Name" FROM "table_name" AS "Table Alias"
```

Please let me know if any additional changes would be helpful!