### PR TITLE
Fix(types): Select.limit field is an object, not an array

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -75,7 +75,7 @@ export interface Select {
   groupby: ColumnRef[] | null;
   having: any[] | null;
   orderby: OrderBy[] | null;
-  limit: Limit[] | null;
+  limit: Limit | null;
 }
 export interface Insert_Replace {
   type: 'replace' | 'insert';

--- a/types.d.ts
+++ b/types.d.ts
@@ -27,9 +27,13 @@ export interface From {
 export interface Dual {
   type: 'dual';
 }
-export interface Limit {
+export interface LimitValue {
   type: string;
   value: number;
+}
+export interface Limit {
+  seperator: string;
+  value: LimitValue[];
 }
 export interface OrderBy {
   type: 'ASC' | 'DESC';


### PR DESCRIPTION
Hey!

Example query

```sql
SELECT
      'Donor City' `donor__city`, count(`donor`._id) `donor__count`
    FROM
      Donors AS `donor`
  GROUP BY 1 ORDER BY 2 DESC LIMIT 10000
```

Ast:

```
{
  "with": null,
  "type": "select",
  "options": null,
  "distinct": null,
  "columns": [
    {
      "expr": {
        "type": "string",
        "value": "Donor City"
      },
      "as": "donor__city"
    },
    {
      "expr": {
        "type": "aggr_func",
        "name": "COUNT",
        "args": {
          "distinct": null,
          "expr": {
            "type": "column_ref",
            "table": "donor",
            "column": "_id"
          }
        },
        "over": null
      },
      "as": "donor__count"
    }
  ],
  "from": [
    {
      "db": null,
      "table": "Donors",
      "as": "donor"
    }
  ],
  "where": null,
  "groupby": [
    {
      "type": "number",
      "value": 1
    }
  ],
  "having": null,
  "orderby": [
    {
      "expr": {
        "type": "number",
        "value": 2
      },
      "type": "DESC"
    }
  ],
  "limit": {
    "seperator": "",
    "value": [
      {
        "type": "number",
        "value": 10000
      }
    ]
  },
  "for_update": null
}
```

As you can see from AST, it's object

Yet another examples:

https://github.com/taozhi8833998/node-sql-parser/blob/master/test/select.spec.js#L639
https://github.com/taozhi8833998/node-sql-parser/blob/master/test/select.spec.js#L652

Thanks
