### PR TITLE
Support Conditional function CASE WHEN in FlinkSQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sql-parser",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "simple node sql parser",
   "main": "index.js",
   "types": "index.d.ts",

--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -71,7 +71,6 @@
     'SESSION_USER': true,
     'SET': true,
     'SHOW': true,
-    'STATUS': true, // reserved (MySQL)
     'SYSTEM_USER': true,
 
     'TABLE': true,
@@ -2287,15 +2286,6 @@ aggr_fun_expr
         args: {
           expr: e,
           distinct: d
-        }
-      };
-    }
-  / name:KW_AGGR_FUNC __ LPAREN __ d:KW_DISTINCT? __ e:primary __ RPAREN {
-      return {
-        type: 'aggr_func',
-        name: name,
-        args: {
-          expr: e
         }
       };
     }

--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -1948,7 +1948,7 @@ expr
   / select_stmt
 
 logic_operator_expr
-  = head:primary tail:(__ LOGIC_OPERATOR __ primary)+ {
+  = head:primary tail:(__ BINARY_OPERATORS __ primary)+ {
     /*
     export type BINARY_OPERATORS = LOGIC_OPERATOR | 'OR' | 'AND' | multiplicative_operator | additive_operator
       | arithmetic_comparison_operator
@@ -2287,6 +2287,15 @@ aggr_fun_expr
         args: {
           expr: e,
           distinct: d
+        }
+      };
+    }
+  / name:KW_AGGR_FUNC __ LPAREN __ d:KW_DISTINCT? __ e:primary __ RPAREN {
+      return {
+        type: 'aggr_func',
+        name: name,
+        args: {
+          expr: e
         }
       };
     }
@@ -2832,6 +2841,7 @@ DOUBLE_WELL_ARROW = '#>>'
 OPERATOR_CONCATENATION = '||'
 OPERATOR_AND = '&&'
 LOGIC_OPERATOR = OPERATOR_CONCATENATION / OPERATOR_AND
+BINARY_OPERATORS = LOGIC_OPERATOR / 'OR' / 'AND' / multiplicative_operator / additive_operator / arithmetic_comparison_operator / 'IN' / 'NOT IN' / 'BETWEEN' / '=' 
 
 // separator
 __

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1334,5 +1334,10 @@ describe('select', () => {
       expect(getParsedSql(sql, opt))
       .to.be.equal('SELECT `userID`, HOP_START(`eventtime`, INTERVAL \'1\' HOUR, INTERVAL \'1\' DAY) AS `hopStart` FROM `tablename` GROUP BY HOP(`eventtime`, INTERVAL \'1\' HOUR, INTERVAL \'1\' DAY)');
     });
+    it('should parse case when conditional function', () => {
+      const sql = `SELECT userID as ID, SUM(CASE col WHEN 'ACTIVE' THEN 1 ELSE 0 END) FROM tablename`;
+      expect(getParsedSql(sql, opt))
+      .to.be.equal('SELECT `userID` AS `ID`, SUM(CASE `col` WHEN \'ACTIVE\' THEN 1 ELSE 0 END) FROM `tablename`');
+    })
   })
 });

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1335,9 +1335,14 @@ describe('select', () => {
       .to.be.equal('SELECT `userID`, HOP_START(`eventtime`, INTERVAL \'1\' HOUR, INTERVAL \'1\' DAY) AS `hopStart` FROM `tablename` GROUP BY HOP(`eventtime`, INTERVAL \'1\' HOUR, INTERVAL \'1\' DAY)');
     });
     it('should parse case when conditional function', () => {
-      const sql = `SELECT userID as ID, SUM(CASE col WHEN 'ACTIVE' THEN 1 ELSE 0 END) FROM tablename`;
+      const sql = `SELECT userID as ID, SUM(CASE col WHEN 'ACTIVE' THEN 1 ELSE 0 END) AS c FROM tablename`;
       expect(getParsedSql(sql, opt))
-      .to.be.equal('SELECT `userID` AS `ID`, SUM(CASE `col` WHEN \'ACTIVE\' THEN 1 ELSE 0 END) FROM `tablename`');
+      .to.be.equal('SELECT `userID` AS `ID`, SUM(CASE `col` WHEN \'ACTIVE\' THEN 1 ELSE 0 END) AS `c` FROM `tablename`');
+    })
+    it('should parse expr contains status', () => {
+      const sql = `SELECT userID AS ID, SUM(CASE status WHEN 'ACTIVE' THEN 1 ELSE 0 END) AS numAcceptedOffers FROM tablename`;
+      expect(getParsedSql(sql, opt))
+      .to.be.equal('SELECT `userID` AS `ID`, SUM(CASE `status` WHEN \'ACTIVE\' THEN 1 ELSE 0 END) AS `numAcceptedOffers` FROM `tablename`');
     })
   })
 });


### PR DESCRIPTION
The expression in the CASE WHEN cannot be recognized. Now this syntax works
```
CASE expression
    WHEN value THEN result
    [WHEN ...]
    [ELSE result]
END
```
But the other one still not work:
```
CASE WHEN condition THEN result
     [WHEN ...]
     [ELSE result]
END
```


The issue created here before:
https://github.com/taozhi8833998/node-sql-parser/issues/457


Note: The PostgreSQL has the same feature, need to apply the same patch later.