### PR TITLE
Add failing mysql tests for where clause with many conditions

### DIFF
--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -40,6 +40,20 @@ describe('AST', () => {
             })
         })
 
+        describe('where clauses', () => {
+            xit("should support where clause with many conditions and backticks", () => {
+                const sql = 'SELECT * FROM `table_name` WHERE (`to_name` = "name" OR `from_name` = "name") AND (`from_rating` <> `to_rating`) OR (`from_rating` IS NULL AND `to_rating` IS NOT NULL)';
+                const ast = parser.astify(sql)
+                expect(ast.from.table).to.equal("table")
+            })
+
+            xit("should support where clause with many conditions", () => {
+                const sql = 'SELECT * FROM table_name WHERE (to_name = "name" OR from_name = "name") OR (from_rating <> to_rating)';
+                const ast = parser.astify(sql)
+                expect(ast.from.table).to.equal("table_name")
+            })
+        })
+
         describe('common table expressions', () => {
             it('should support single CTE', () => {
                 const sql = `WITH cte AS (SELECT 1)


### PR DESCRIPTION
We use `node-sql-parser` for our website (https://www.dolthub.com). We've been using version 2.3.0 until today when we upgraded to 3.1.0. I added some failing skipped tests that were working and broke with the upgrade to the newest version. We're using a temporary workaround, but would really appreciate a fix. 

Thank you!