### PR TITLE
Unbalanced lengths between column count and row count

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1282,6 +1282,14 @@ replace_insert_stmt
       }
       if (c) {
         let table = t && t.table || null
+
+        if(Array.isArray(v)) {
+          v.forEach((row, idx) => {
+            if(row.value.length != c.length) {
+              throw new Error(`Error: column count doesn't match value count at row ${idx+1}`)
+            }
+          })
+        }
         c.forEach(c => columnList.add(`insert::${table}::${c}`));
       }
       return {

--- a/test/insert.spec.js
+++ b/test/insert.spec.js
@@ -31,6 +31,12 @@ describe('insert', () => {
       expect(backSQL).to.be.equal("INSERT INTO `t1` VALUES ('1223','name'),('1224','name2')")
     })
 
+    it("should throw error if column count doesn't match value count", () => {
+      const sql = 'INSERT INTO t1 (col1, col2, col3) values("1223", "name"), ("1224", "name2")'
+      const fun = parser.astify.bind(parser, sql)
+      expect(fun).to.throw("column count doesn't match value count at row 1")
+    })
+
     it('should support parse insert from select', () => {
       const sql = 'INSERT INTO t1(col_a, col_b) select col_a, col_b from t2'
       const ast = parser.astify(sql)


### PR DESCRIPTION
Hi, a query like this with different count between columns and rows will be successfully parsed:
```
  INSERT INTO t1 (col1, col2, col3) values("1223", "name"), ("1224", "name2")
```
I have added a tentative correction.