### PR TITLE
Remove non-reserved Postgres type keyword

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -77,7 +77,6 @@
     'THEN': true,
     'TRUE': true,
     'TRUNCATE': true,
-    'TYPE': true,   // reserved (MySQL)
 
     'UNION': true,
     'UPDATE': true,


### PR DESCRIPTION
`type` is non-reserved in [`postgresql`](https://www.postgresql.org/docs/8.1/sql-keywords-appendix.html).

If you have a table with a column named `type` then the query:

```
SELECT id, type from my_table;
```

Fails to parse; however, this is valid SQL that Postgres processes correctly. 