### PR TITLE
Remove non-reserved interval keyword

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -41,7 +41,6 @@
     'INNER': true,
     'INSERT': true,
     'INTO': true,
-    'INTERVAL': true,
     'IS': true,
 
     'JOIN': true,


### PR DESCRIPTION
`interval` is not reserved in [postgres](https://www.postgresql.org/docs/8.1/sql-keywords-appendix.html). For example, `SELECT id, interval from table` is valid PostgreSQL but this library fails to parse it. 