### PR TITLE
fix: remove duplicate key `CREATE`

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -19,7 +19,6 @@
     'CALL': true,
     'CASCADE': true,
     'CASE': true,
-    'CREATE': true,
     'CHAR': true,
     'CHECK': true,
     'COLLATE': true,


### PR DESCRIPTION
[In ECMAScript 5 strict mode code, duplicate property names were considered a SyntaxError.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#:~:text=In%20ECMAScript%205%20strict%20mode%20code%2C%20duplicate%20property%20names%20were%20considered%20a%20SyntaxError.)