### PR TITLE
refactor: support function name with more dot in bigquery

### DIFF
--- a/pegjs/bigquery.pegjs
+++ b/pegjs/bigquery.pegjs
@@ -1183,10 +1183,10 @@ func_call
   }
 
 proc_func_name
-  = dt:ident tail:(__ DOT __ ident)? {
+  = dt:ident tail:(__ DOT __ ident)* {
       let name = dt
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        tail.forEach(t => name = `${name}.${t[3]}`)
       }
       return name;
     }

--- a/test/bigquery.spec.js
+++ b/test/bigquery.spec.js
@@ -536,7 +536,13 @@ describe('BigQuery', () => {
         'select row_number() over(), * from retail.orders',
         'SELECT row_number() OVER (), * FROM retail.orders'
       ]
-
+    },
+    {
+      title: 'function name with more dot',
+      sql: [
+        'SELECT bqutil.fn.degrees(3.141592653589793) is_this_pi',
+        'SELECT bqutil.fn.degrees(3.141592653589793) AS is_this_pi'
+      ]
     },
   ]
 


### PR DESCRIPTION
- fix #943 