### PR TITLE
refactor: escape with cte

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -104,7 +104,7 @@
     };
   }
 
-  function createBinaryExpr(op, left, right, others = {}) {
+  function createBinaryExpr(op, left, right) {
     return {
       type: 'binary_expr',
       operator: op,

--- a/src/with.js
+++ b/src/with.js
@@ -1,6 +1,6 @@
 import { columnRefToSQL } from './column'
 import { exprToSQL } from './expr'
-import { literalToSQL } from './util'
+import { identifierToSql, literalToSQL } from './util'
 
 /**
  * @param {Array<Object>} withExpr
@@ -11,7 +11,7 @@ function withToSQL(withExpr) {
   const withExprStr = withExpr.map(cte => {
     const { name, stmt, columns } = cte
     const column = Array.isArray(columns) ? `(${columns.map(columnRefToSQL).join(', ')})` : ''
-    return `${literalToSQL(name)}${column} AS (${exprToSQL(stmt)})`
+    return `${name.type === 'default' ? identifierToSql(name.value) : literalToSQL(name)}${column} AS (${exprToSQL(stmt)})`
   }).join(', ')
 
   return `WITH ${isRecursive}${withExprStr}`

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -44,15 +44,13 @@ describe('AST', () => {
             it('should support single CTE', () => {
                 const sql = `WITH cte AS (SELECT 1)
                             SELECT * FROM cte`;
-                expect(getParsedSql(sql)).to.equal('WITH cte AS (SELECT 1) SELECT * FROM `cte`');
+                expect(getParsedSql(sql)).to.equal('WITH `cte` AS (SELECT 1) SELECT * FROM `cte`');
             });
 
             it('should support multiple CTE', () => {
-                 const sql = `WITH cte1 AS (SELECT 1), cte2 AS (SELECT 2)
+                const sql = `WITH cte1 AS (SELECT 1), cte2 AS (SELECT 2)
                               SELECT * FROM cte1 UNION SELECT * FROM cte2`;
-
-
-                let expected = 'WITH cte1 AS (SELECT 1), cte2 AS (SELECT 2) ' +
+                const expected = 'WITH `cte1` AS (SELECT 1), `cte2` AS (SELECT 2) ' +
                                'SELECT * FROM `cte1` UNION SELECT * FROM `cte2`';
                 expect(getParsedSql(sql)).to.equal(expected)
             });
@@ -60,14 +58,12 @@ describe('AST', () => {
             it('should support CTE with column', () => {
                 const sql = `WITH cte (col1) AS (SELECT 1)
                             SELECT * FROM cte`;
-
                 expect(getParsedSql(sql)).to.contain('(`col1`)');
             });
 
             it('should support CTE with multiple columns', () => {
                 const sql = `WITH cte (col1, col2) AS (SELECT 1, 2)
                              SELECT * FROM \`cte\``;
-
                 expect(getParsedSql(sql)).to.contain('(`col1`, `col2`)');
             });
 

--- a/test/mysql-mariadb.spec.js
+++ b/test/mysql-mariadb.spec.js
@@ -342,6 +342,13 @@ describe('mysql', () => {
           'SHOW CREATE VIEW `abc`.`test`'
         ]
       },
+      {
+        title: 'with',
+        sql: [
+          'WITH cte AS (SELECT id, ROW_NUMBER() OVER (PARTITION BY id, uid ORDER BY time DESC) ranking FROM t) SELECT id FROM cte WHERE ranking = 1',
+          'WITH `cte` AS (SELECT `id`, ROW_NUMBER() OVER (PARTITION BY `id`, `uid` ORDER BY `time` DESC) AS `ranking` FROM `t`) SELECT `id` FROM `cte` WHERE `ranking` = 1'
+        ]
+      }
     ]
     SQL_LIST.forEach(sqlInfo => {
       const { title, sql } = sqlInfo

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -20,7 +20,7 @@ describe('Postgres', () => {
         subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),
         subQ2 AS (SELECT SchoolID FROM subQ1)
       SELECT DISTINCT * FROM subQ2;`,
-      `WITH subQ1 AS (SELECT * FROM "Roster" WHERE "SchoolID" = 52), subQ2 AS (SELECT "SchoolID" FROM "subQ1") SELECT DISTINCT * FROM "subQ2"`
+      `WITH "subQ1" AS (SELECT * FROM "Roster" WHERE "SchoolID" = 52), "subQ2" AS (SELECT "SchoolID" FROM "subQ1") SELECT DISTINCT * FROM "subQ2"`
      ]
     },
     {
@@ -264,7 +264,7 @@ describe('Postgres', () => {
         )
         select a[2]
         from t`,
-        `WITH t AS (SELECT ARRAY['a','b','c'] AS "a") SELECT "a"[2] FROM "t"`
+        `WITH "t" AS (SELECT ARRAY['a','b','c'] AS "a") SELECT "a"[2] FROM "t"`
       ]
     },
     {
@@ -581,7 +581,7 @@ describe('Postgres', () => {
             values ('Closed'), ('Verified'), ('Done')
           ) s(a)
         ) select * from statuses`,
-        `WITH statuses AS (SELECT "a" FROM (VALUES ('Closed'), ('Verified'), ('Done')) AS "s(a)") SELECT * FROM "statuses"`
+        `WITH "statuses" AS (SELECT "a" FROM (VALUES ('Closed'), ('Verified'), ('Done')) AS "s(a)") SELECT * FROM "statuses"`
       ]
     },
     {
@@ -622,7 +622,7 @@ describe('Postgres', () => {
         )
         SELECT id
         FROM new_stuff;`,
-        `CREATE TABLE "stuff" ("id" SERIAL PRIMARY KEY, "name" VARCHAR) ; WITH new_stuff AS (INSERT INTO "stuff" ("name") VALUES ('foo'), ('bar') RETURNING "id") SELECT "id" FROM "new_stuff"`
+        `CREATE TABLE "stuff" ("id" SERIAL PRIMARY KEY, "name" VARCHAR) ; WITH "new_stuff" AS (INSERT INTO "stuff" ("name") VALUES ('foo'), ('bar') RETURNING "id") SELECT "id" FROM "new_stuff"`
       ]
     },
     {

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -230,7 +230,7 @@ describe('select', () => {
       SELECT
         EXTRACT(EPOCH FROM ts)
       FROM
-        tss`, opt), opt)).to.eql('WITH tss AS (SELECT CURRENT_TIMESTAMP AS "ts") SELECT EXTRACT(EPOCH FROM "ts") FROM "tss"');
+        tss`, opt), opt)).to.eql('WITH "tss" AS (SELECT CURRENT_TIMESTAMP AS "ts") SELECT EXTRACT(EPOCH FROM "ts") FROM "tss"');
       });
 
       it('should parse function expression', () => {


### PR DESCRIPTION
- related to #1090, escape with `cte` when sqlify