### PR TITLE
Added support for mysql/mariadb locking read

### DIFF
--- a/pegjs/mariadb.pegjs
+++ b/pegjs/mariadb.pegjs
@@ -1197,6 +1197,26 @@ cte_column_definition
       return l
     }
 
+for_update
+  = fu:('FOR'i __ KW_UPDATE) {
+    return `${fu[0]} ${fu[2][0]}`
+  }
+
+lock_in_share_mode
+  = m:('LOCK'i __ 'IN'i __ 'SHARE'i __ 'MODE'i) {
+    return `${m[0]} ${m[2]} ${m[4]} ${m[6]}`
+  }
+
+lock_option
+  = w:('WAIT'i __ literal_numeric) { return `${w[0]} ${w[2].value}` }
+  / nw:'NOWAIT'i
+  / sl:('SKIP'i __ 'LOCKED'i) { return `${sl[0]} ${sl[2]}` }
+
+locking_read
+  = t:(for_update / lock_in_share_mode) __ lo:lock_option? {
+    return t + (lo ? ` ${lo}` : '')
+  }
+
 select_stmt_nake
   = __ cte:with_clause? __ KW_SELECT ___
     opts:option_clause? __
@@ -1210,7 +1230,7 @@ select_stmt_nake
     h:having_clause?    __
     o:order_by_clause?  __
     l:limit_clause? __
-    fu: ('FOR'i __ KW_UPDATE)? __
+    lr: locking_read? __
     win:window_clause? __
     li:into_clause?  {
       if ((ci && fi) || (ci && li) || (fi && li) || (ci && fi && li)) {
@@ -1233,7 +1253,7 @@ select_stmt_nake
           having: h,
           orderby: o,
           limit: l,
-          for_update: fu && `${fu[0]} ${fu[2][0]}`,
+          locking_read: lr && lr,
           window: win,
       };
   }

--- a/src/select.js
+++ b/src/select.js
@@ -52,7 +52,7 @@ function selectToSQL(stmt) {
     distinct,
     from,
     for_sys_time_as_of: forSystem = {},
-    for_update: forUpdate,
+    locking_read: lockingRead,
     groupby,
     having,
     into = {},
@@ -84,7 +84,7 @@ function selectToSQL(stmt) {
   clauses.push(commonOptionConnector('WINDOW', exprToSQL, windowInfo))
   clauses.push(orderOrPartitionByToSQL(orderby, 'order by'))
   clauses.push(limitToSQL(limit))
-  clauses.push(toUpper(forUpdate))
+  clauses.push(toUpper(lockingRead))
   if (position === 'end') clauses.push(intoSQL)
   const sql = clauses.filter(hasVal).join(' ')
   return parentheses ? `(${sql})` : sql

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -71,6 +71,41 @@ describe('select', () => {
     expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 FOR UPDATE');
   });
 
+  it('should support for update with wait', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 for update wait 1234');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 FOR UPDATE WAIT 1234');
+  });
+
+  it('should support for update with nowait', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 for update nowait');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 FOR UPDATE NOWAIT');
+  });
+
+  it('should support for update with skip locked', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 for update skip locked');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 FOR UPDATE SKIP LOCKED');
+  });
+
+  it('should support lock in share mode', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 lock in share mode');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 LOCK IN SHARE MODE');
+  });
+
+  it('should support lock in share mode with wait', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 lock in share mode wait 1234');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 LOCK IN SHARE MODE WAIT 1234');
+  });
+
+   it('should support lock in share mode witn nowait', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 lock in share mode nowait');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 LOCK IN SHARE MODE NOWAIT');
+  });
+
+  it('should support lock in share mode with skip locked', () => {
+    const ast = parser.astify('select SOME_COLUMN from TABLE_NAME where ID_COLUMN = 0 lock in share mode skip locked');
+    expect(parser.sqlify(ast)).to.eql('SELECT `SOME_COLUMN` FROM `TABLE_NAME` WHERE `ID_COLUMN` = 0 LOCK IN SHARE MODE SKIP LOCKED');
+  });
+
   it('should support div as divsion', () => {
     expect(getParsedSql('SELECT * FROM businesses WHERE  SUBSTRING(street_physical, 1, LENGTH(street_physical) div 2) = SUBSTRING(street_physical, LENGTH(street_physical) DIV 2 + 1, LENGTH(street_physical) / 2);'))
     .to.be.equal('SELECT * FROM `businesses` WHERE SUBSTRING(`street_physical`, 1, LENGTH(`street_physical`) DIV 2) = SUBSTRING(`street_physical`, LENGTH(`street_physical`) DIV 2 + 1, LENGTH(`street_physical`) / 2)')
@@ -387,7 +422,7 @@ describe('select', () => {
               type: 'select',
               options: null,
               distinct: null,
-              for_update: null,
+              locking_read: null,
               from: [{ db: null, table: 't1', as: null }],
               columns: [{ expr: { type: 'column_ref', table: null, column: 'id' }, as: null }],
               into: { position: null },
@@ -453,7 +488,7 @@ describe('select', () => {
                 type: 'select',
                 options: null,
                 distinct: null,
-                for_update: null,
+                locking_read: null,
                 from: [{ db: null, table: 't2', as: null }],
                 columns: [
                   { expr: { type: 'column_ref', table: null, 'column': 'id' }, as: null },
@@ -628,7 +663,7 @@ describe('select', () => {
               type: 'select',
               options: null,
               distinct: null,
-              for_update: null,
+              locking_read: null,
               columns: [{ expr: { type: 'number', value: 1 }, as: null }],
               into: { position: null },
               from: null,


### PR DESCRIPTION
Hi, mysql/maria DB implement locking reads:
Ref:
  https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
  https://mariadb.com/kb/en/select/

This PR adds support for it.
