### PR TITLE
fix: count distinct without parentheses in bigquery

### DIFF
--- a/pegjs/bigquery.pegjs
+++ b/pegjs/bigquery.pegjs
@@ -2373,6 +2373,8 @@ count_arg
   = e:star_expr { return { expr: e }; }
   / d:KW_DISTINCT? __ c:column_ref { return { distinct: d, expr: c }; }
   / d:KW_DISTINCT? __ LPAREN __ c:expr __ RPAREN __ or:order_by_clause? {  return { distinct: d, expr: c, orderby: or, parentheses: true }; }
+  / d:KW_DISTINCT? __ c:expr __ or:order_by_clause? {  return { distinct: d, expr: c, orderby: or, parentheses: false }; }
+
 
 star_expr
   = "*" { return { type: 'star', value: '*' }; }

--- a/test/bigquery.spec.js
+++ b/test/bigquery.spec.js
@@ -628,6 +628,18 @@ describe('BigQuery', () => {
         'SELECT CURRENT_DATE'
       ]
     },
+    {
+      title: 'count distinct case when without parentheses',
+      sql: [
+        `SELECT
+        COUNT(
+          DISTINCT CASE WHEN active IS TRUE THEN id END
+        ) AS nb_active
+      FROM
+        dataset.users`,
+        'SELECT COUNT(DISTINCT CASE WHEN active IS TRUE THEN id END) AS nb_active FROM dataset.users'
+      ]
+    },
   ]
 
   SQL_LIST.forEach(sqlInfo => {


### PR DESCRIPTION
- fix #1185