### PR TITLE
Fix index with asc desc columns

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1509,12 +1509,12 @@ cte_column_definition
     }
 
 column_idx_ref
-  = c:column __ so:(KW_ASC / KW_DESC)? {
+  = col:column_without_kw __ ob:(KW_ASC / KW_DESC)? {
       return {
-        type: 'column_in_index',
-        name: c,
-        sort_order: so
-      }
+        type: 'column_ref',
+        column: col,
+        order_by: ob
+      };
     }
 
 column_ref_idx_list

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1511,7 +1511,8 @@ cte_column_definition
 column_idx_ref
   = c:column __ so:(KW_ASC / KW_DESC)? {
       return {
-        column: c,
+        type: 'column_in_index',
+        name: c,
         sort_order: so
       }
     }

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1061,7 +1061,7 @@ create_index_definition
   = kc:(KW_INDEX / KW_KEY) __
     c:column? __
     t:index_type? __
-    de:cte_column_definition __
+    de:cte_idx_column_definition __
     id:index_options? __ {
       return {
         index: c,
@@ -1505,6 +1505,24 @@ cte_definition
 
 cte_column_definition
   = LPAREN __ l:column_ref_index __ RPAREN {
+      return l
+    }
+
+column_idx_ref
+  = c:column __ so:(KW_ASC / KW_DESC)? {
+      return {
+        column: c,
+        sort_order: so
+      }
+    }
+
+column_ref_idx_list
+  = head:column_idx_ref tail:(__ COMMA __ column_idx_ref)* {
+      return createList(head, tail);
+    }
+
+cte_idx_column_definition
+  = LPAREN __ l:column_ref_idx_list __ RPAREN {
       return l
     }
 

--- a/src/column.js
+++ b/src/column.js
@@ -22,7 +22,7 @@ function columnOffsetToSQL(column, isDual) {
 function columnRefToSQL(expr) {
   const {
     array_index, arrows = [], as, collate, column, isDual, schema, table, parentheses, properties,
-    suffix,
+    suffix, order_by,
   } = expr
   let str = column === '*' ? '*' : columnOffsetToSQL(column, isDual)
   if (table) str = `${identifierToSql(table)}.${str}`
@@ -38,6 +38,7 @@ function columnRefToSQL(expr) {
   ]
   if (collate) result.push(commonTypeValue(collate).join(' '))
   result.push(toUpper(suffix))
+  result.push(toUpper(order_by))
   const sql = result.filter(hasVal).join(' ')
   return parentheses ? `(${sql})` : sql
 }
@@ -173,16 +174,9 @@ function columnsToSQL(columns, tables) {
   return result.filter(hasVal).join(' ')
 }
 
-function columnInIndexToSQL(column) {
-  const { name: columnName, sort_order: sortOrder } = column
-  const result = [identifierToSql(columnName), toUpper(sortOrder)]
-  return result.filter(hasVal).join(' ')
-}
-
 export {
   columnDefinitionToSQL,
   columnRefToSQL,
-  columnInIndexToSQL,
   columnsToSQL,
   columnDataType,
   columnOrderToSQL,

--- a/src/column.js
+++ b/src/column.js
@@ -173,9 +173,16 @@ function columnsToSQL(columns, tables) {
   return result.filter(hasVal).join(' ')
 }
 
+function columnInIndexToSQL(column) {
+  const { name: columnName, sort_order: sortOrder } = column
+  const result = [identifierToSql(columnName), toUpper(sortOrder)]
+  return result.filter(hasVal).join(' ')
+}
+
 export {
   columnDefinitionToSQL,
   columnRefToSQL,
+  columnInIndexToSQL,
   columnsToSQL,
   columnDataType,
   columnOrderToSQL,

--- a/src/expr.js
+++ b/src/expr.js
@@ -4,7 +4,7 @@ import { aggrToSQL } from './aggregation'
 import { assignToSQL } from './assign'
 import { binaryToSQL } from './binary'
 import { caseToSQL } from './case'
-import { columnRefToSQL, fulltextSearchToSQL } from './column'
+import { columnRefToSQL, fulltextSearchToSQL, columnInIndexToSQL } from './column'
 import { castToSQL, extractFunToSQL, funcToSQL } from './func'
 import { intervalToSQL } from './interval'
 import { selectToSQL } from './select'
@@ -23,6 +23,7 @@ const exprToSQLConvertFn = {
   case            : caseToSQL,
   cast            : castToSQL,
   column_ref      : columnRefToSQL,
+  column_in_index : columnInIndexToSQL,
   datatype        : dataTypeToSQL,
   extract         : extractFunToSQL,
   fulltext_search : fulltextSearchToSQL,

--- a/src/expr.js
+++ b/src/expr.js
@@ -4,7 +4,7 @@ import { aggrToSQL } from './aggregation'
 import { assignToSQL } from './assign'
 import { binaryToSQL } from './binary'
 import { caseToSQL } from './case'
-import { columnRefToSQL, fulltextSearchToSQL, columnInIndexToSQL } from './column'
+import { columnRefToSQL, fulltextSearchToSQL } from './column'
 import { castToSQL, extractFunToSQL, funcToSQL } from './func'
 import { intervalToSQL } from './interval'
 import { selectToSQL } from './select'
@@ -23,7 +23,6 @@ const exprToSQLConvertFn = {
   case            : caseToSQL,
   cast            : castToSQL,
   column_ref      : columnRefToSQL,
-  column_in_index : columnInIndexToSQL,
   datatype        : dataTypeToSQL,
   extract         : extractFunToSQL,
   fulltext_search : fulltextSearchToSQL,

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -281,7 +281,7 @@ describe('Command SQL', () => {
       })
     })
 
-    it.only(`should support MySQL alter add index or key`, () => {
+    it(`should support MySQL alter add index or key`, () => {
       ["index", "key"].forEach(keyword => {
         expect(getParsedSql(`alter table a add ${keyword} (\`name\`, \`alias\`)`))
         .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} (\`name\`, \`alias\`)`);

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -281,36 +281,36 @@ describe('Command SQL', () => {
       })
     })
 
-    it(`should support MySQL alter add index or key`, () => {
+    it.only(`should support MySQL alter add index or key`, () => {
       ["index", "key"].forEach(keyword => {
-        expect(getParsedSql(`alter table a add ${keyword} ("name", "alias")`))
-        .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} ('name', 'alias')`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx ("name", "alias")`))
-          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx ('name', 'alias')`);
-        expect(getParsedSql(`ALTER TABLE \`a\` ADD ${keyword} name_idx using btree ("name", "alias")`))
-          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx USING BTREE ('name', 'alias')`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx ("name", "alias") KEY_BLOCK_SIZE = 324`))
-          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx ('name', 'alias') KEY_BLOCK_SIZE = 324`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash ("name", "alias") KEY_BLOCK_SIZE = 324`))
-          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx USING HASH ('name', 'alias') KEY_BLOCK_SIZE = 324`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash ("name", "alias") KEY_BLOCK_SIZE 123`))
+        expect(getParsedSql(`alter table a add ${keyword} (\`name\`, \`alias\`)`))
+        .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} (\`name\`, \`alias\`)`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx (\`name\`, \`alias\`)`))
+          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx (\`name\`, \`alias\`)`);
+        expect(getParsedSql(`ALTER TABLE \`a\` ADD ${keyword} name_idx using btree (\`name\`, \`alias\`)`))
+          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx USING BTREE (\`name\`, \`alias\`)`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx (\`name\`, \`alias\`) KEY_BLOCK_SIZE = 324`))
+          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx (\`name\`, \`alias\`) KEY_BLOCK_SIZE = 324`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash (\`name\`, \`alias\`) KEY_BLOCK_SIZE = 324`))
+          .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()} name_idx USING HASH (\`name\`, \`alias\`) KEY_BLOCK_SIZE = 324`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash (\`name\`, \`alias\`) KEY_BLOCK_SIZE 123`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx USING HASH ('name', 'alias') KEY_BLOCK_SIZE 123`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash ("name", "alias") with parser parser_name`))
+          } name_idx USING HASH (\`name\`, \`alias\`) KEY_BLOCK_SIZE 123`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash (\`name\`, \`alias\`) with parser parser_name`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx USING HASH ('name', 'alias') WITH PARSER parser_name`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash ("name", "alias") visible`))
+          } name_idx USING HASH (\`name\`, \`alias\`) WITH PARSER parser_name`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash (\`name\`, \`alias\`) visible`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx USING HASH ('name', 'alias') VISIBLE`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash ("name", "alias") invisible`))
+          } name_idx USING HASH (\`name\`, \`alias\`) VISIBLE`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx using hash (\`name\`, \`alias\`) invisible`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx USING HASH ('name', 'alias') INVISIBLE`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx ("name", "alias") using hash`))
+          } name_idx USING HASH (\`name\`, \`alias\`) INVISIBLE`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx (\`name\`, \`alias\`) using hash`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx ('name', 'alias') USING HASH`);
-        expect(getParsedSql(`alter table a add ${keyword} name_idx ("name", "alias") using btree`))
+          } name_idx (\`name\`, \`alias\`) USING HASH`);
+        expect(getParsedSql(`alter table a add ${keyword} name_idx (\`name\`, \`alias\`) using btree`))
           .to.equal(`ALTER TABLE \`a\` ADD ${keyword.toUpperCase()
-          } name_idx ('name', 'alias') USING BTREE`);
+          } name_idx (\`name\`, \`alias\`) USING BTREE`);
       })
     });
 

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -166,21 +166,21 @@ describe('create', () => {
       });
 
       ['index', 'key'].forEach(type => {
-        it.only(`should support create table ${type}`, () => {
-          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} idx_name using hash (name) key_block_size 128) engine = innodb auto_increment = 10`))
-          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} idx_name USING HASH (\`name\`) KEY_BLOCK_SIZE 128) ENGINE = INNODB AUTO_INCREMENT = 10`);
+        it(`should support create table ${type}`, () => {
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} idx_name using hash (name) key_block_size 128) engine = innodb auto_increment = 10`))
+            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} idx_name USING HASH (\`name\`) KEY_BLOCK_SIZE 128) ENGINE = INNODB AUTO_INCREMENT = 10`);
 
-          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible)`))
-          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE)`);
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible)`))
+            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE)`);
 
-          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser)`))
-          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser)`);
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser)`))
+            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser)`);
 
-          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser comment "index comment")`))
-          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser COMMENT 'index comment')`);
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser comment "index comment")`))
+            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser COMMENT 'index comment')`);
 
-          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 invisible with parser newparser comment "index comment")`))
-          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 invisible with parser newparser comment "index comment")`))
+            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
 
           expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (\`id\` asc, \`name\` desc) key_block_size = 128 invisible with parser newparser comment "index comment")`))
           .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`id\` ASC, \`name\` DESC) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -166,7 +166,7 @@ describe('create', () => {
       });
 
       ['index', 'key'].forEach(type => {
-        it(`should support create table ${type}`, () => {
+        it.only(`should support create table ${type}`, () => {
           expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} idx_name using hash (name) key_block_size 128) engine = innodb auto_increment = 10`))
             .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} idx_name USING HASH (\`name\`) KEY_BLOCK_SIZE 128) ENGINE = INNODB AUTO_INCREMENT = 10`);
 
@@ -181,6 +181,9 @@ describe('create', () => {
 
           expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 invisible with parser newparser comment "index comment")`))
             .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
+
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (id asc, name desc) key_block_size = 128 invisible with parser newparser comment "index comment")`))
+          .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`id\` ASC, \`name\` DESC) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
         })
       })
 

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -167,22 +167,22 @@ describe('create', () => {
 
       ['index', 'key'].forEach(type => {
         it.only(`should support create table ${type}`, () => {
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} idx_name using hash (name) key_block_size 128) engine = innodb auto_increment = 10`))
-            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} idx_name USING HASH (\`name\`) KEY_BLOCK_SIZE 128) ENGINE = INNODB AUTO_INCREMENT = 10`);
+          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} idx_name using hash (name) key_block_size 128) engine = innodb auto_increment = 10`))
+          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} idx_name USING HASH (\`name\`) KEY_BLOCK_SIZE 128) ENGINE = INNODB AUTO_INCREMENT = 10`);
 
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible)`))
-            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE)`);
+          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible)`))
+          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE)`);
 
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser)`))
-            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser)`);
+          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser)`))
+          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser)`);
 
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser comment "index comment")`))
-            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser COMMENT 'index comment')`);
+          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 visible with parser newparser comment "index comment")`))
+          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 VISIBLE WITH PARSER newparser COMMENT 'index comment')`);
 
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 invisible with parser newparser comment "index comment")`))
-            .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
+          // expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (name) key_block_size = 128 invisible with parser newparser comment "index comment")`))
+          //   .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`name\`) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
 
-          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (id asc, name desc) key_block_size = 128 invisible with parser newparser comment "index comment")`))
+          expect(getParsedSql(`create temporary table dbname.tableName (id int, name varchar(128), ${type} using btree (\`id\` asc, \`name\` desc) key_block_size = 128 invisible with parser newparser comment "index comment")`))
           .to.equal(`CREATE TEMPORARY TABLE \`dbname\`.\`tableName\` (\`id\` INT, \`name\` VARCHAR(128), ${type.toUpperCase()} USING BTREE (\`id\` ASC, \`name\` DESC) KEY_BLOCK_SIZE = 128 INVISIBLE WITH PARSER newparser COMMENT 'index comment')`);
         })
       })


### PR DESCRIPTION
Mysql [accepts `ASC` / `DESC` keywords for each column in the index](https://dev.mysql.com/doc/refman/8.0/en/descending-indexes.html), but the parser fails for those.
Also, the output of the `ALTER TABLE ... ADD KEY / INDEX` is invalid as it's using single quotes, while only backticks are allowed.
