### PR TITLE
feat: status as column name in flink

### DIFF
--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -71,7 +71,7 @@
     'SESSION_USER': true,
     'SET': true,
     'SHOW': true,
-    'STATUS': true, // reserved (MySQL)
+    // 'STATUS': true,
     'SYSTEM_USER': true,
 
     'TABLE': true,

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -48,6 +48,13 @@ describe('Flink', () => {
         "SELECT TRIM(' test ') AS `TrimmedString`",
       ],
     },
+    {
+      title: "status as column name",
+      sql: [
+        `SELECT status FROM users;`,
+        "SELECT `status` FROM `users`",
+      ],
+    },
   ];
 
   SQL_LIST.forEach(sqlInfo => {


### PR DESCRIPTION
This PR removes `status` from the list of reserved keyword in Flink.