### PR TITLE
feat: support is distinct from in flink

### DIFF
--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -2140,6 +2140,7 @@ comparison_op_right
   / in_op_right
   / exists_op_right
   / between_op_right
+  / distinct_from_op_right
   / is_op_right
   / like_op_right
   / jsonb_op_right
@@ -2188,6 +2189,15 @@ between_op_right
 between_or_not_between_op
   = nk:(KW_NOT __ KW_BETWEEN) { /* => 'NOT BETWEEN' */ return nk[0] + ' ' + nk[2]; }
   / KW_BETWEEN
+
+distinct_from_op
+  = KW_IS __ KW_NOT __ KW_DISTINCT __ KW_FROM { /* => 'IS NOT DISTINCT FROM' */ return 'IS NOT DISTINCT FROM'; }
+  / KW_IS __ KW_DISTINCT __ KW_FROM { /* => 'IS DISTINCT FROM' */ return 'IS DISTINCT FROM'; }
+
+distinct_from_op_right
+  = op:distinct_from_op __ right:(expr) {
+      return { op: op, right: right };
+    }
 
 like_op
   = nk:(KW_NOT __ KW_LIKE) { /* => 'LIKE' */ return nk[0] + ' ' + nk[2]; }

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -161,6 +161,27 @@ describe('Flink', () => {
         "SELECT `user`, `amount` FROM `Orders` WHERE `product` NOT EXISTS (SELECT `product` FROM `NewProducts`)",
       ],
     },
+    {
+      title: "DISTINCT FROM",
+      sql: [
+        `SELECT * FROM users WHERE a IS DISTINCT FROM 'b'`,
+        "SELECT * FROM `users` WHERE `a` IS DISTINCT FROM 'b'",
+      ],
+    },
+    {
+      title: "NOT DISTINCT FROM",
+      sql: [
+        `SELECT * FROM users WHERE a IS NOT DISTINCT FROM b`,
+        "SELECT * FROM `users` WHERE `a` IS NOT DISTINCT FROM `b`",
+      ],
+    },
+    {
+      title: "DISTINCT FROM NULL",
+      sql: [
+        `SELECT * FROM users WHERE a IS DISTINCT FROM NULL`,
+        "SELECT * FROM `users` WHERE `a` IS DISTINCT FROM NULL",
+      ],
+    },
   ];
 
   SQL_LIST.forEach(sqlInfo => {


### PR DESCRIPTION
This PR adds support for the [`IS [NOT] DISTINCT FROM` comparison function](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/functions/systemfunctions/#comparison-functions).