### PR TITLE
feat: support substring in flink

### DIFF
--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -2551,8 +2551,34 @@ trim_func_clause
     };
   }
 
+substring_func_args
+  = e:expr __ KW_FROM __ start:literal_numeric length:(__ 'for'i __ literal_numeric)? {
+    // => expr_list
+    let value = [e, { type: 'origin', value: 'from' }, start]
+    if (length) {
+      value.push({ type: 'origin', value: 'for' })
+      value.push(length[3])
+    }
+    return {
+      type: 'expr_list',
+      value,
+    }
+  }
+
+substring_func_clause
+  = 'SUBSTRING'i __ LPAREN __ args:substring_func_args __ RPAREN {
+    // => { type: 'function'; name: string; args: expr_list; }
+    return {
+        type: 'function',
+        name: 'SUBSTRING',
+        separator: ' ',
+        args,
+    };
+  }
+
 func_call
   = trim_func_clause
+  / substring_func_clause
   / name:proc_func_name __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
       // => { type: 'function'; name: string; args: expr_list; }
       if (l && l.type !== 'expr_list') l = { type: 'expr_list', value: [l] }

--- a/src/func.js
+++ b/src/func.js
@@ -48,7 +48,7 @@ function funcToSQL(expr) {
   const collateStr = commonTypeValue(collate).join(' ')
   const overStr = overToSQL(over)
   if (!args) return [name, overStr].filter(hasVal).join(' ')
-  let separator = ', '
+  let separator = expr.separator || ', '
   if (toUpper(name) === 'TRIM') separator = ' '
   let str = [name]
   str.push(args_parentheses === false ? ' ' : '(')

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -217,6 +217,20 @@ describe('Flink', () => {
         "SELECT * FROM `users` WHERE `a` SIMILAR TO '%[^a-z0-9 .]%' ESCAPE '-'",
       ],
     },
+    {
+      title: "SUBSTRING",
+      sql: [
+        `SELECT * FROM users WHERE SUBSTRING('abcde' FROM 2) = 'llo'`,
+        "SELECT * FROM `users` WHERE SUBSTRING('abcde' FROM 2) = 'llo'",
+      ],
+    },
+    {
+      title: "SUBSTRING with length",
+      sql: [
+        `SELECT * FROM users WHERE SUBSTRING(a FROM 2 FOR 2) = 'll'`,
+        "SELECT * FROM `users` WHERE SUBSTRING(`a` FROM 2 FOR 2) = 'll'",
+      ],
+    },
   ];
 
   SQL_LIST.forEach(sqlInfo => {


### PR DESCRIPTION
This PR adds support for [`SUBSTRING`](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/functions/systemfunctions/#string-functions) in Flink.