### PR TITLE
feat: support position in flink

### DIFF
--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -2813,6 +2813,31 @@ count_arg
 star_expr
   = "*" { /* => { type: 'star'; value: '*' } */ return { type: 'star', value: '*' }; }
 
+position_func_args
+  = s:literal_string __ KW_IN __ e:expr start:(__ KW_FROM __ literal_numeric)? {
+    // => expr_list
+    let value = [s, { type: 'origin', value: 'in' }, e]
+    if (start) {
+      value.push({ type: 'origin', value: 'from' })
+      value.push(start[3])
+    }
+    return {
+      type: 'expr_list',
+      value,
+    }
+  }
+
+position_func_clause
+  = 'POSITION'i __ LPAREN __ args:position_func_args __ RPAREN {
+    // => { type: 'function'; name: string; args: expr_list; }
+    return {
+        type: 'function',
+        name: 'POSITION',
+        separator: ' ',
+        args,
+    };
+  }
+
 trim_position
   = 'BOTH'i / 'LEADING'i / 'TRAILING'i
 
@@ -2867,7 +2892,8 @@ substring_func_clause
   }
 
 func_call
-  = trim_func_clause
+  = position_func_clause
+  / trim_func_clause
   / substring_func_clause
   / name:proc_func_name __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
       // => { type: 'function'; name: string; args: expr_list; }

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -218,6 +218,20 @@ describe('Flink', () => {
       ],
     },
     {
+      title: "POSITION",
+      sql: [
+        `SELECT * FROM users WHERE POSITION('a' IN a) = 2`,
+        "SELECT * FROM `users` WHERE POSITION('a' IN `a`) = 2",
+      ],
+    },
+    {
+      title: "POSITION with start",
+      sql: [
+        `SELECT * FROM users WHERE POSITION('a' IN a FROM 3) = 2`,
+        "SELECT * FROM `users` WHERE POSITION('a' IN `a` FROM 3) = 2",
+      ],
+    },
+    {
       title: "SUBSTRING",
       sql: [
         `SELECT * FROM users WHERE SUBSTRING('abcde' FROM 2) = 'llo'`,


### PR DESCRIPTION
This PR adds support for [`POSITION`](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/functions/systemfunctions/#string-functions) in Flink.