### PR TITLE
feat: support all join operations in flink

### DIFF
--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -1926,10 +1926,16 @@ table_base
     }
 
 join_op
-  = KW_LEFT __ KW_OUTER? __ KW_JOIN { /* => 'LEFT JOIN' */ return 'LEFT JOIN'; }
-  / KW_RIGHT __ KW_OUTER? __ KW_JOIN { /* =>  'RIGHT JOIN' */ return 'RIGHT JOIN'; }
-  / KW_FULL __ KW_OUTER? __ KW_JOIN { /* => 'FULL JOIN' */ return 'FULL JOIN'; }
-  / (KW_INNER __)? KW_JOIN { /* => 'INNER JOIN' */ return 'INNER JOIN'; }
+  = n:KW_NATURAL? __ d:(KW_LEFT / KW_RIGHT / KW_FULL)? __ o:KW_OUTER? __ KW_JOIN {
+      /* => [ NATURAL ] [ { LEFT | RIGHT | FULL } [ OUTER ] ] JOIN */
+      const natural = n ? 'NATURAL ' : '';
+      const direction = d ? `${d} ` : '';
+      const outer = o ? 'OUTER ' : '';
+      return `${natural}${direction}${outer}JOIN`;
+    }
+  / i:(KW_INNER __)? KW_JOIN { /* => 'INNER JOIN' */ return i ? 'INNER JOIN' : 'JOIN'; }
+  / KW_CROSS __ KW_JOIN { /* => 'CROSS JOIN' */ return 'CROSS JOIN'; }
+  / ko:(KW_CROSS / KW_OUTER) __ KW_APPLY { /* => '[ CROSS | OUTER ] APPLY' */ return `${ko[0].toUpperCase()} APPLY`; }
 
 table_name
   = dt:ident schema:(__ DOT __ ident) tail:(__ DOT __ ident) {
@@ -3204,11 +3210,14 @@ KW_SCHEME   = "SCHEME"i      !ident_start { return 'SCHEME'; }
 KW_COLLATE  = "COLLATE"i    !ident_start { return 'COLLATE'; }
 
 KW_ON       = "ON"i       !ident_start
-KW_LEFT     = "LEFT"i     !ident_start
-KW_RIGHT    = "RIGHT"i    !ident_start
-KW_FULL     = "FULL"i     !ident_start
-KW_INNER    = "INNER"i    !ident_start
+KW_NATURAL  = "NATURAL"i  !ident_start { return 'NATURAL'; }
+KW_LEFT     = "LEFT"i     !ident_start { return 'LEFT'; }
+KW_RIGHT    = "RIGHT"i    !ident_start { return 'RIGHT'; }
+KW_FULL     = "FULL"i     !ident_start { return 'FULL'; }
+KW_INNER    = "INNER"i    !ident_start { return 'INNER'; }
 KW_JOIN     = "JOIN"i     !ident_start
+KW_CROSS    = "CROSS"i    !ident_start
+KW_APPLY    = "APPLY"i    !ident_start
 KW_OUTER    = "OUTER"i    !ident_start
 KW_UNION    = "UNION"i    !ident_start { return 'UNION'; }
 KW_INTERSECT    = "INTERSECT"i    !ident_start { return 'INTERSECT'; }

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -190,6 +190,85 @@ describe('Flink', () => {
       ],
     },
     {
+      title: "JOIN",
+      sql: [
+        `SELECT * FROM Orders JOIN Product ON Orders.productId = Product.id`,
+        "SELECT * FROM `Orders` JOIN `Product` ON `Orders`.`productId` = `Product`.`id`",
+      ],
+    },
+    {
+      title: "NATURAL JOIN",
+      sql: [
+        `SELECT * FROM Orders NATURAL JOIN Product`,
+        "SELECT * FROM `Orders` NATURAL JOIN `Product`",
+      ],
+    },
+    {
+      title: "INNER JOIN",
+      sql: [
+        `SELECT * FROM Orders INNER JOIN Product ON Orders.productId = Product.id`,
+        "SELECT * FROM `Orders` INNER JOIN `Product` ON `Orders`.`productId` = `Product`.`id`",
+      ],
+    },
+    {
+      title: "LEFT JOIN",
+      sql: [
+        `SELECT * FROM Orders LEFT JOIN Product ON Orders.product_id = Product.id`,
+        "SELECT * FROM `Orders` LEFT JOIN `Product` ON `Orders`.`product_id` = `Product`.`id`",
+      ],
+    },
+    {
+      title: "RIGHT JOIN",
+      sql: [
+        `SELECT * FROM Orders RIGHT JOIN Product ON Orders.product_id = Product.id`,
+        "SELECT * FROM `Orders` RIGHT JOIN `Product` ON `Orders`.`product_id` = `Product`.`id`",
+      ],
+    },
+    {
+      title: "FULL OUTER JOIN",
+      sql: [
+        `SELECT * FROM Orders FULL OUTER JOIN Product ON Orders.product_id = Product.id`,
+        "SELECT * FROM `Orders` FULL OUTER JOIN `Product` ON `Orders`.`product_id` = `Product`.`id`",
+      ],
+    },
+    {
+      title: "CROSS JOIN",
+      sql: [
+        `SELECT column_list FROM A CROSS JOIN B`,
+        "SELECT `column_list` FROM `A` CROSS JOIN `B`",
+      ],
+    },
+    {
+      title: "CROSS APPLY",
+      sql: [
+        `SELECT  t1.*, t2o.*
+         FROM    t1
+         CROSS APPLY
+                (
+                SELECT  *
+                FROM    t2
+                WHERE   t2.t1_id = t1.id
+                ) t2o
+        `,
+        "SELECT `t1`.*, `t2o`.* FROM `t1` CROSS APPLY (SELECT * FROM `t2` WHERE `t2`.`t1_id` = `t1`.`id`) AS `t2o`",
+      ],
+    },
+    {
+      title: "complex JOINs",
+      sql: [
+        `SELECT * FROM (SELECT * FROM table1) t1 FULL OUTER JOIN ( SELECT * FROM ( SELECT * FROM table2 ) JOIN db.table3 ON table2.id=table3.id ) t2 ON t1.id=t2.id`,
+        "SELECT * FROM (SELECT * FROM `table1`) AS `t1` FULL OUTER JOIN (SELECT * FROM (SELECT * FROM `table2`) JOIN `db`.`table3` ON `table2`.`id` = `table3`.`id`) AS `t2` ON `t1`.`id` = `t2`.`id`",
+      ],
+    },
+    {
+      title: "WITH clause",
+      sql: [
+        `WITH orders_with_total AS (SELECT order_id, price + tax AS total FROM Orders)
+         SELECT order_id, SUM(total) FROM orders_with_total GROUP BY order_id;`,
+        "WITH `orders_with_total` AS (SELECT `order_id`, `price` + `tax` AS `total` FROM `Orders`) SELECT `order_id`, SUM(`total`) FROM `orders_with_total` GROUP BY `order_id`",
+      ],
+    },
+    {
       title: "string concatenation function",
       sql: [
         `SELECT a || b FROM users WHERE a || b = 'ab';`,


### PR DESCRIPTION
This PR adds support for [all join operations](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/queries/joins/) in Flink. See also [the relevant section of Calcite's Grammar](https://calcite.apache.org/docs/reference.html#grammar).