### PR TITLE
Support union distinct on various databases

### DIFF
--- a/ast/postgresql.ts
+++ b/ast/postgresql.ts
@@ -20,11 +20,11 @@ export type crud_stmt = union_stmt | update_stmt | replace_insert_stmt | insert_
 
 export type multiple_stmt = AstStatement<crud_stmt[]>;
 
-export type set_op = 'union' | 'union all';
+export type set_op = 'union' | 'union all' | 'union distinct';
 
 export interface union_stmt_node extends select_stmt_node  {
          _next: union_stmt_node;
-         set_op: 'union' | 'union all';
+         set_op: 'union' | 'union all' | 'union distinct';
       }
 
 export type union_stmt = AstStatement<union_stmt_node>;

--- a/pegjs/db2.pegjs
+++ b/pegjs/db2.pegjs
@@ -246,8 +246,9 @@ multiple_stmt
       }
     }
 set_op
-  = KW_UNION __ KW_ALL { return 'union all' }
-  / KW_UNION { return 'union' }
+  = KW_UNION __ s:(KW_ALL / KW_DISTINCT)? {
+    return s ? `union ${s.toLowerCase()}` : 'union'
+  }
 
 union_stmt
   = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {

--- a/pegjs/flinksql.pegjs
+++ b/pegjs/flinksql.pegjs
@@ -549,7 +549,7 @@ multiple_stmt
     }
 
 set_op
-  = u:(KW_UNION / KW_INTERSECT / KW_EXCEPT) __ s:KW_ALL? {
+  = u:(KW_UNION / KW_INTERSECT / KW_EXCEPT) __ s:(KW_ALL / KW_DISTINCT)? {
     return s ? `${u.toLowerCase()} ${s.toLowerCase()}` : `${u.toLowerCase()}`
   }
 
@@ -557,7 +557,7 @@ union_stmt
   = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {
      /* export interface union_stmt_node extends select_stmt_node  {
          _next: union_stmt_node;
-         union: 'union' | 'union all';
+         union: 'union' | 'union all' | 'union distinct';
       }
      => AstStatement<union_stmt_node>
      */

--- a/pegjs/hive.pegjs
+++ b/pegjs/hive.pegjs
@@ -246,8 +246,9 @@ multiple_stmt
       }
     }
 set_op
-  = KW_UNION __ KW_ALL { return 'union all' }
-  / KW_UNION { return 'union' }
+  = KW_UNION __ s:(KW_ALL / KW_DISTINCT)? {
+    return s ? `union ${s.toLowerCase()}` : 'union'
+  }
 
 union_stmt
   = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {

--- a/pegjs/mariadb.pegjs
+++ b/pegjs/mariadb.pegjs
@@ -262,8 +262,9 @@ multiple_stmt
     }
 
 set_op
-  = KW_UNION __ KW_ALL { return 'union all' }
-  / KW_UNION { return 'union' }
+  = KW_UNION __ s:(KW_ALL / KW_DISTINCT)? {
+    return s ? `union ${s.toLowerCase()}` : 'union'
+  }
   / KW_MINUS { return 'minus' }
   / KW_INTERSECT { return 'intersect' }
 

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -457,8 +457,9 @@ multiple_stmt
     }
 
 set_op
-  = KW_UNION __ KW_ALL { return 'union all' }
-  / KW_UNION { return 'union' }
+  = KW_UNION __ s:(KW_ALL / KW_DISTINCT)? {
+    return s ? `union ${s.toLowerCase()}` : 'union'
+  }
   / KW_MINUS { return 'minus' }
   / KW_INTERSECT { return 'intersect' }
 

--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -267,16 +267,16 @@ multiple_stmt
     }
 
 set_op
-  = KW_UNION __ a:KW_ALL? {
-    // => 'union' | 'union all'
-    return a ? 'union all' : 'union'
+  = KW_UNION __ a:(KW_ALL / KW_DISTINCT)? {
+    // => 'union' | 'union all' | 'union distinct'
+    return a ? `union ${a.toLowerCase()}` : 'union'
   }
 
 union_stmt
   = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {
      /* export interface union_stmt_node extends select_stmt_node  {
          _next: union_stmt_node;
-         set_op: 'union' | 'union all';
+         set_op: 'union' | 'union all' | 'union distinct';
       }
      => AstStatement<union_stmt_node>
      */

--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -253,8 +253,9 @@ multiple_stmt
     }
 
 set_op
-  = KW_UNION __ KW_ALL { return 'union all' }
-  / KW_UNION { return 'union' }
+  = KW_UNION __ s:(KW_ALL / KW_DISTINCT)? {
+    return s ? `union ${s.toLowerCase()}` : 'union'
+  }
 
 union_stmt
   = head:select_stmt tail:(__ set_op __ select_stmt)* __ ob: order_by_clause? __ l:limit_clause? {

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -657,13 +657,11 @@ describe('AST', () => {
 
             it('should combine multiple statements union all', () => {
                 sql = `select 1 union all select '1' union select a from t union all (select true)`;
-                const ast =
                 expect(getParsedSql(sql)).to.equal(`SELECT 1 UNION ALL SELECT '1' UNION SELECT \`a\` FROM \`t\` UNION ALL (SELECT TRUE)`);
             });
 
             it('should combine multiple statements union distinct', () => {
               sql = `select 1 union distinct select '1' union select a from t union distinct (select true)`;
-              const ast =
               expect(getParsedSql(sql)).to.equal(`SELECT 1 UNION DISTINCT SELECT '1' UNION SELECT \`a\` FROM \`t\` UNION DISTINCT (SELECT TRUE)`);
             });
 

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -661,6 +661,12 @@ describe('AST', () => {
                 expect(getParsedSql(sql)).to.equal(`SELECT 1 UNION ALL SELECT '1' UNION SELECT \`a\` FROM \`t\` UNION ALL (SELECT TRUE)`);
             });
 
+            it('should combine multiple statements union distinct', () => {
+              sql = `select 1 union distinct select '1' union select a from t union distinct (select true)`;
+              const ast =
+              expect(getParsedSql(sql)).to.equal(`SELECT 1 UNION DISTINCT SELECT '1' UNION SELECT \`a\` FROM \`t\` UNION DISTINCT (SELECT TRUE)`);
+            });
+
             it('should support sqlify without ast', () => {
                 const ast = [{
                     ast: {

--- a/test/flink.spec.js
+++ b/test/flink.spec.js
@@ -71,6 +71,13 @@ describe('Flink', () => {
       ],
     },
     {
+      title: "UNION DISTINCT",
+      sql: [
+        `(SELECT s FROM t1) UNION DISTINCT (SELECT s FROM t2)`,
+        "(SELECT `s` FROM `t1`) UNION DISTINCT (SELECT `s` FROM `t2`)",
+      ],
+    },
+    {
       title: "INTERSECT",
       sql: [
         `(SELECT s FROM t1) INTERSECT (SELECT s FROM t2)`,

--- a/test/hive.spec.js
+++ b/test/hive.spec.js
@@ -100,4 +100,15 @@ describe('Hive', () => {
     sql = "SELECT timestamp '2012-10-31 01:00 UTC';"
     expect(getParsedSql(sql)).to.be.equal("SELECT TIMESTAMP '2012-10-31 01:00 UTC'")
   })
+
+  it("should support union", () => {
+    let sql = `select * from a union select * from b`
+    expect(getParsedSql(sql)).to.be.equal("SELECT * FROM `a` UNION SELECT * FROM `b`")
+
+    sql = `select * from a union all select * from b`
+    expect(getParsedSql(sql)).to.be.equal("SELECT * FROM `a` UNION ALL SELECT * FROM `b`")
+
+    sql = `select * from a union distinct select * from b`
+    expect(getParsedSql(sql)).to.be.equal("SELECT * FROM `a` UNION DISTINCT SELECT * FROM `b`")
+  })
 })

--- a/test/mysql-mariadb.spec.js
+++ b/test/mysql-mariadb.spec.js
@@ -492,6 +492,27 @@ describe('mysql', () => {
         ]
       },
       {
+        title: 'set op UNION',
+        sql: [
+          `SELECT * FROM (SELECT 1) union SELECT * FROM (SELECT 2)`,
+          'SELECT * FROM (SELECT 1) UNION SELECT * FROM (SELECT 2)'
+        ]
+      },
+      {
+        title: 'set op UNION ALL',
+        sql: [
+          `SELECT * FROM (SELECT 1) union all SELECT * FROM (SELECT 2)`,
+          'SELECT * FROM (SELECT 1) UNION ALL SELECT * FROM (SELECT 2)'
+        ]
+      },
+      {
+        title: 'set op UNION DISTINCT',
+        sql: [
+          `SELECT * FROM (SELECT 1) union distinct SELECT * FROM (SELECT 2)`,
+          'SELECT * FROM (SELECT 1) UNION DISTINCT SELECT * FROM (SELECT 2)'
+        ]
+      },
+      {
         title: 'set op INTERSECT',
         sql: [
           `SELECT * FROM (SELECT 1) intersect SELECT * FROM (SELECT 2)`,

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -61,6 +61,27 @@ describe('Postgres', () => {
       ]
     },
     {
+      title: 'set op UNION',
+      sql: [
+        `(SELECT s FROM t1) UNION (SELECT s FROM t2)`,
+        '(SELECT "s" FROM "t1") UNION (SELECT "s" FROM "t2")',
+      ],
+    },
+    {
+      title: 'set op UNION ALL',
+      sql: [
+        `(SELECT s FROM t1) UNION ALL (SELECT s FROM t2)`,
+        '(SELECT "s" FROM "t1") UNION ALL (SELECT "s" FROM "t2")',
+      ],
+    },
+    {
+      title: 'set op UNION DISTINCT',
+      sql: [
+        `(SELECT s FROM t1) UNION DISTINCT (SELECT s FROM t2)`,
+        '(SELECT "s" FROM "t1") UNION DISTINCT (SELECT "s" FROM "t2")',
+      ],
+    },
+    {
         title: 'Window Fns with qualified frame clause',
         sql: [
           `SELECT
@@ -1083,7 +1104,7 @@ describe('Postgres', () => {
 
   describe('tables to sql', () => {
     it('should parse object tables', () => {
-      const ast = parser.astify(SQL_LIST[97].sql[0], opt)
+      const ast = parser.astify(SQL_LIST[100].sql[0], opt)
       ast[0].from[0].expr.parentheses = false
       expect(parser.sqlify(ast, opt)).to.be.equal('SELECT "last_name", "salary" FROM "employees" INNER JOIN "salaries" ON "employees"."emp_no" = "salaries"."emp_no"')
     })

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1396,6 +1396,16 @@ describe('select', () => {
       expect(getParsedSql(sql, opt)).to.be.equal('SELECT 1 FROM "pg_database" AS "a" WHERE "a"."oid" IN (SELECT 1 FROM "pg_database" AS "b" WHERE "b"."oid" = 1 UNION SELECT 1 FROM "pg_database" AS "c" WHERE "c"."oid" = 2)')
     })
 
+    it('should support union distinct in in_op', () => {
+      const sql = `select 1 from pg_database a where a.oid in
+        (
+      select 1 from pg_database b where b.oid = 1
+      union distinct
+      select 1 from pg_database c where c.oid=2
+      )`
+      expect(getParsedSql(sql, opt)).to.be.equal('SELECT 1 FROM "pg_database" AS "a" WHERE "a"."oid" IN (SELECT 1 FROM "pg_database" AS "b" WHERE "b"."oid" = 1 UNION DISTINCT SELECT 1 FROM "pg_database" AS "c" WHERE "c"."oid" = 2)')
+    })
+
     it('should support array_agg', () => {
       let sql = `SELECT shipmentId, ARRAY_AGG(distinct abc order by name) AS shipmentStopIDs, ARRAY_AGG (first_name || ' ' || last_name) actors FROM table_name GROUP BY shipmentId`
       expect(getParsedSql(sql, opt)).to.equal('SELECT "shipmentId", ARRAY_AGG(DISTINCT "abc" ORDER BY "name" ASC) AS "shipmentStopIDs", ARRAY_AGG("first_name" || \' \' || "last_name") AS "actors" FROM "table_name" GROUP BY "shipmentId"')

--- a/test/sqlite.spec.js
+++ b/test/sqlite.spec.js
@@ -128,4 +128,15 @@ describe('sqlite', () => {
     END;`
     expect(getParsedSql(sql)).to.be.equal('CREATE TRIGGER `update_customer_address` UPDATE OF `address` ON `customers` BEGIN UPDATE `orders` SET `address` = `new`.`address` WHERE `customer_name` = `old`.`name` END')
   })
+
+  it('should support union', () => {
+    let sql = `SELECT * FROM a UNION SELECT * FROM b`
+    expect(getParsedSql(sql)).to.be.equal('SELECT * FROM `a` UNION SELECT * FROM `b`')
+
+    sql = `SELECT * FROM a UNION ALL SELECT * FROM b`
+    expect(getParsedSql(sql)).to.be.equal('SELECT * FROM `a` UNION ALL SELECT * FROM `b`')
+
+    sql = `SELECT * FROM a UNION DISTINCT SELECT * FROM b`
+    expect(getParsedSql(sql)).to.be.equal('SELECT * FROM `a` UNION DISTINCT SELECT * FROM `b`')
+  })
 })


### PR DESCRIPTION
Hi maintainers, I fixed https://github.com/taozhi8833998/node-sql-parser/issues/1537

Changed to pegjs file to support union distinct on below databases (I supported only databases where documents could be found)
- [db2](https://www.ibm.com/docs/en/db2-for-zos/12?topic=statement-combining-result-tables-from-multiple-select-statements#taskdb2z_combineresultmultipleselect__context__1)
- [flinksql](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/hive-compatibility/hive-dialect/queries/set-op/#union)
- [hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Union)
- [mariadb](https://mariadb.com/kb/en/union/)
- [mysql](https://dev.mysql.com/doc/refman/8.0/en/union.html)
- [postgresql](https://www.postgresql.org/docs/current/sql-select.html)
- sqlite ([blog1](https://www.w3resource.com/sqlite/sqlite-union.php), [blog2](https://www.techonthenet.com/sqlite/union.php))

I am not familiar with this library, my changes may not be enough. Please let me know if so.