### PR TITLE
allow db prefix in column_refs

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1631,7 +1631,7 @@ show_stmt
       }
     }
   }
-  / KW_SHOW __ k:(('CHARACTER'i __ 'SET'i) / 'COLLATION'i) __ e:(like_op_right / where_clause)? {
+  / KW_SHOW __ k:(('CHARACTER'i __ 'SET'i) / 'COLLATION'i / 'DATABASES'i) __ e:(like_op_right / where_clause)? {
     let keyword = Array.isArray(k) && k || [k]
     return {
       tableList: Array.from(tableList),

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -2041,7 +2041,7 @@ column_list_item
         as: null
       };
     }
-  / a:assign_stmt {
+  / a:select_assign_stmt {
     return { expr: a, as: null }
   }
   / e:binary_column_expr __ alias:alias_clause? {
@@ -3748,6 +3748,16 @@ proc_stmt
 
 assign_stmt
   = va:(var_decl / without_prefix_var_decl) __ s: (KW_ASSIGN / KW_ASSIGIN_EQUAL) __ e:proc_expr {
+    return {
+      type: 'assign',
+      left: va,
+      symbol: s,
+      right: e
+    };
+  }
+
+select_assign_stmt
+  = va:(var_decl / without_prefix_var_decl) __ s:KW_ASSIGN __ e:proc_expr {
     return {
       type: 'assign',
       left: va,


### PR DESCRIPTION
select db.table.column from db.table is valid syntax in mysql.