### PR TITLE
feat: support exec stmt without parameters

### DIFF
--- a/pegjs/transactsql.pegjs
+++ b/pegjs/transactsql.pegjs
@@ -639,7 +639,7 @@ declare_stmt
   }
 
 exec_stmt
-  = kw:('EXEC'i / 'EXECUTE'i) __ t:table_name __ v:exec_varibale_list {
+  = kw:('EXECUTE'i / 'EXEC'i) __ t:table_name __ v:exec_varibale_list? {
     return {
       tableList: Array.from(tableList),
       columnList: columnListTableAlias(columnList),

--- a/src/exec.js
+++ b/src/exec.js
@@ -13,7 +13,7 @@ function execToSQL(stmt) {
   const result = [
     toUpper(keyword),
     tableToSQL(module),
-    parameters.map(execVariablesToSQL).filter(hasVal).join(', '),
+    (parameters || []).map(execVariablesToSQL).filter(hasVal).join(', '),
   ]
   return result.filter(hasVal).join(' ')
 }

--- a/test/transactsql.spec.js
+++ b/test/transactsql.spec.js
@@ -58,6 +58,11 @@ describe('transactsql', () => {
     expect(getParsedSql(sql)).to.equal("EXEC [msdb].[dbo].[sp_delete_database_backuphistory] @database_name = N'Test' GO")
   })
 
+  it('should support execute stmt without parameters', () => {
+    const sql = `EXECUTE sys.sp_who`
+    expect(getParsedSql(sql)).to.equal("EXECUTE [sys].[sp_who]")
+  })
+
   it('should support over in aggregation function', () => {
     let sql = `select sum(order_rate) over(
       order by quarter_time


### PR DESCRIPTION
- feat: support exec statement without execute parameters
- fix: fix the problem which causes 'execute' keyword cannot be recognized