### PR TITLE
drop index support in alter command

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1194,6 +1194,15 @@ ALTER_DROP_KEY
         type: 'alter',
     }
   }
+  / KW_DROP __ (KW_KEY / KW_INDEX) __ c:ident_name {
+    return {
+        action: 'drop',
+        index: c,
+        keyword: 'index',
+        resource: 'index',
+        type: 'alter',
+    }
+  }
 
 ALTER_DROP_CONSTRAINT
   = KW_DROP __ kc:'CHECK'i __ c:ident_name {


### PR DESCRIPTION
Support `ALTER TABLE table_name DROP INDEX index_name` and `ALTER TABLE table_name DROP KEY index_name`