### PR TITLE
Use typeof comparaison on global object for browsers usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ if (typeof self === "object" && self) {
   }
 }
 
-if (!global && typeof window === "object" && window) window.global = window
+if (typeof global === "undefined" && typeof window === "object" && window) window.global = window
 
 if (typeof global === "object" && global && global.window) {
   global.window.NodeSQLParser = {


### PR DESCRIPTION
This PR aims to use the `typeof` keyword to make it working with browsers.

Using `!global` in browser would make crash as `global` object is not defined in browsers.