### PR TITLE
fix(snowflake): support the REGEXP / NOT REGEXP operator

### DIFF
--- a/test/snowflake.spec.js
+++ b/test/snowflake.spec.js
@@ -119,6 +119,21 @@ describe('snowflake', () => {
         `SELECT "listing_id", "listing_name", "room_type", "host_id", REPLACE("price_str", '$')::NUMBER(10, 2) AS "price", "created_at", "updated_at" FROM "src_listings"`
       ]
     },
+    {
+      title: 'regexp operator',
+      sql: [
+        `SELECT v
+    FROM strings
+    WHERE v REGEXP 'San* [fF].*'
+
+    UNION ALL
+
+    SELECT v
+    FROM strings
+    WHERE v NOT REGEXP 'San\\w+?o'`,
+        'SELECT "v" FROM "strings" WHERE "v" REGEXP \'San* [fF].*\' UNION ALL SELECT "v" FROM "strings" WHERE "v" NOT REGEXP \'San\\w+?o\''
+      ]
+    }
   ]
   SQL_LIST.forEach(sqlInfo => {
     const { title, sql } = sqlInfo


### PR DESCRIPTION
Snowflake has REGEXP / NOT REGEXP but lacks ~ and ! ~

This PR adjusts the syntax accordingly
https://docs.snowflake.com/en/sql-reference/functions/regexp

Fixes: https://github.com/taozhi8833998/node-sql-parser/issues/1823 
