### PR TITLE
refactor: change all function with all quoted object

### DIFF
--- a/pegjs/athena.pegjs
+++ b/pegjs/athena.pegjs
@@ -766,7 +766,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -1814,6 +1814,18 @@ column_list
       return createList(head, tail);
     }
 
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
+
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
+
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
       return name;
@@ -1833,19 +1845,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -1958,7 +1988,7 @@ func_call
   = name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'origin', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -1966,7 +1996,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -1974,7 +2004,7 @@ func_call
     if (l && l.type !== 'expr_list') l = { type: 'expr_list', value: [l] }
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc,
         args_parentheses: false,
@@ -2509,12 +2539,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/pegjs/bigquery.pegjs
+++ b/pegjs/bigquery.pegjs
@@ -1480,7 +1480,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -2367,6 +2367,18 @@ column_list
       return createList(head, tail);
     }
 
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
+
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
+
 ident
   = name:ident_name !{ return reservedMap[`${name}`.toUpperCase()] === true; } {
       return name;
@@ -2382,23 +2394,41 @@ alias_ident
     } {
       return name;
     }
-  / name:quoted_ident {
+  / name:quoted_ident_type {
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return `\`${chars.join('')}\``; }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = column_name / quoted_ident
@@ -2521,7 +2551,7 @@ func_call
   / name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -2529,7 +2559,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -2544,12 +2574,13 @@ func_call
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)* {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)* {
+      const result = { name: [dt] }
       if (tail !== null) {
-        tail.forEach(t => name = `${name}.${t[3]}`)
+        result.schema = dt
+        result.name = tail.map(t => t[3])
       }
-      return name;
+      return result
     }
 
 scalar_time_func
@@ -2609,7 +2640,7 @@ extract_func
   / 'DATE_TRUNC'i __  LPAREN __ e:expr __ COMMA __ f:extract_filed __ RPAREN {
     return {
         type: 'function',
-        name: 'DATE_TRUNC',
+        name: { name: [{ type: 'origin', value: 'date_trunc' }]},
         args: { type: 'expr_list', value: [e, { type: 'origin', value: f }] },
         over: null,
       };

--- a/pegjs/db2.pegjs
+++ b/pegjs/db2.pegjs
@@ -827,7 +827,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -1832,6 +1832,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
+
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
@@ -1852,19 +1863,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -1970,7 +1999,7 @@ func_call
   = name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -1978,7 +2007,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -2506,12 +2535,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/pegjs/hive.pegjs
+++ b/pegjs/hive.pegjs
@@ -766,7 +766,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -1813,7 +1813,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
 
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
       return name;
@@ -1833,19 +1843,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -1958,7 +1986,7 @@ func_call
   = name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -1966,7 +1994,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -1974,7 +2002,7 @@ func_call
     if (l && l.type !== 'expr_list') l = { type: 'expr_list', value: [l] }
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc,
         args_parentheses: false,
@@ -2508,12 +2536,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/pegjs/mariadb.pegjs
+++ b/pegjs/mariadb.pegjs
@@ -1346,7 +1346,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -2791,6 +2791,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
+
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident_without_kw
   = ident_name / quoted_ident
 ident
@@ -2811,19 +2822,37 @@ alias_ident
     }
   / quoted_ident
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:([^`\\] / escape_char)+ "`" { return chars.join(''); }
+  = "`" chars:([^`\\] / escape_char)+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -2833,7 +2862,9 @@ column_without_kw
 
 column
   = name:column_name !{ return reservedMap[name.toUpperCase()] === true; } { return name; }
-  / backticks_quoted_ident
+  / n:backticks_quoted_ident {
+    return n.value
+  }
 
 column_name
   =  start:ident_start parts:column_part* { return start + parts.join(''); }
@@ -3091,7 +3122,7 @@ extract_func
   / 'DATE_TRUNC'i __  LPAREN __ e:expr __ COMMA __ f:extract_filed __ RPAREN {
     return {
         type: 'function',
-        name: 'DATE_TRUNC',
+        name: { name: [{ type: 'origin', value: 'date_trunc' }]},
         args: { type: 'expr_list', value: [e, { type: 'origin', value: f }] },
         over: null,
       };
@@ -3118,7 +3149,7 @@ trim_func_clause
     args.value.push(s)
     return {
         type: 'function',
-        name: 'TRIM',
+        name: { name: [{ type: 'origin', value: 'trim' }]},
         args,
     };
   }
@@ -3128,7 +3159,7 @@ func_call
   / 'convert'i __ LPAREN __ l:convert_args __ RPAREN __ ca:collate_expr? {
     return {
         type: 'function',
-        name: 'CONVERT',
+        name: { name: [{ type: 'origin', value: 'convert' }] },
         args: l,
         collate: ca,
     };
@@ -3136,7 +3167,7 @@ func_call
   / name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -3144,13 +3175,13 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
-  / name:proc_func_name &{ return name.toLowerCase() !== 'convert' && !reservedFunctionName[name.toLowerCase()] } __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
+  / name:proc_func_name &{ return !reservedFunctionName[name.name[0] && name.name[0].value.toLowerCase()] } __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
     if (l && l.type !== 'expr_list') l = { type: 'expr_list', value: [l] }
-    if ((name.toUpperCase() === 'TIMESTAMPDIFF' || name.toUpperCase() === 'TIMESTAMPADD') && l.value && l.value[0]) l.value[0] = { type: 'origin', value: l.value[0].column }
+    if (((name.name[0] && name.name[0].value.toUpperCase() === 'TIMESTAMPDIFF') || (name.name[0] && name.name[0].value.toUpperCase() === 'TIMESTAMPADD')) && l.value && l.value[0]) l.value[0] = { type: 'origin', value: l.value[0].column }
       return {
         type: 'function',
         name: name,
@@ -3758,12 +3789,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:(ident_name / quoted_ident) tail:(__ DOT __ (ident_name / quoted_ident))? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call_args

--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -284,6 +284,7 @@
     avg: true,
     sum: true,
     count: true,
+    convert: true,
     max: true,
     min: true,
     group_concat: true,
@@ -295,7 +296,7 @@
     current_user: true,
     user: true,
     session_user: true,
-    system_user: true
+    system_user: true,
   }
 
   function createUnaryExpr(op, e) {
@@ -1582,7 +1583,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -3076,7 +3077,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
 
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident_without_kw
   = ident_name / quoted_ident
 ident
@@ -3099,19 +3110,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:([^`\\] / escape_char)+ "`" { return chars.join(''); }
+  = "`" chars:([^`\\] / escape_char)+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -3121,7 +3150,9 @@ column_without_kw
 
 column
   = name:column_name !{ return reservedMap[name.toUpperCase()] === true; } { return name; }
-  / backticks_quoted_ident
+  / n:backticks_quoted_ident {
+    return n.value
+  }
 
 column_name
   =  start:ident_start parts:column_part* { return start + parts.join(''); }
@@ -3377,7 +3408,7 @@ extract_func
   / 'DATE_TRUNC'i __  LPAREN __ e:expr __ COMMA __ f:extract_filed __ RPAREN {
     return {
         type: 'function',
-        name: 'DATE_TRUNC',
+        name: { name: [{ type: 'origin', value: 'date_trunc' }]},
         args: { type: 'expr_list', value: [e, { type: 'origin', value: f }] },
         over: null,
       };
@@ -3404,7 +3435,7 @@ trim_func_clause
     args.value.push(s)
     return {
         type: 'function',
-        name: 'TRIM',
+        name: { name: [{ type: 'origin', value: 'trim' }]},
         args,
     };
   }
@@ -3414,7 +3445,7 @@ func_call
   / 'convert'i __ LPAREN __ l:convert_args __ RPAREN __ ca:collate_expr? {
     return {
         type: 'function',
-        name: 'CONVERT',
+        name: { name: [{ type: 'origin', value: 'convert' }] },
         args: l,
         collate: ca,
     };
@@ -3422,7 +3453,7 @@ func_call
   / name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -3430,13 +3461,13 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
-  / name:proc_func_name &{ return name.toLowerCase() !== 'convert' && !reservedFunctionName[name.toLowerCase()] } __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
+  / name:proc_func_name &{ return !reservedFunctionName[name.name[0] && name.name[0].value.toLowerCase()] } __ LPAREN __ l:or_and_where_expr? __ RPAREN __ bc:over_partition? {
     if (l && l.type !== 'expr_list') l = { type: 'expr_list', value: [l] }
-    if ((name.toUpperCase() === 'TIMESTAMPDIFF' || name.toUpperCase() === 'TIMESTAMPADD') && l.value && l.value[0]) l.value[0] = { type: 'origin', value: l.value[0].column }
+    if (((name.name[0] && name.name[0].value.toUpperCase() === 'TIMESTAMPDIFF') || (name.name[0] && name.name[0].value.toUpperCase() === 'TIMESTAMPADD')) && l.value && l.value[0]) l.value[0] = { type: 'origin', value: l.value[0].column }
       return {
         type: 'function',
         name: name,
@@ -4080,19 +4111,14 @@ proc_primary
     }
 
 proc_func_name
-  = dt:(ident_name / quoted_ident) tail:(__ DOT __ (ident_name / quoted_ident))? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
-    / n:ident_name {
-      const upperName = n.toUpperCase()
-      if (reservedMap[upperName] === true) return upperName
-      return n
-    }
-    / quoted_ident
 
 proc_func_call_args
   = name:proc_func_name __ LPAREN __ l:proc_primary_list? __ RPAREN {

--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -1936,7 +1936,7 @@ reference_option
     // => { type: 'function'; name: string; args: expr_list; }
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }] },
       args: l
     }
   }
@@ -4448,7 +4448,7 @@ trim_func_clause
     args.value.push(s)
     return {
         type: 'function',
-        name: { name: { type: 'origin', value: 'trim' }},
+        name: { name: [{ type: 'origin', value: 'trim' }] },
         args,
     };
   }
@@ -4458,11 +4458,11 @@ tablefunc_clause
     // => { type: 'tablefunc'; name: proc_func_name; args: expr_list; as: func_call }
     return {
       type: 'tablefunc',
-      name: { name: { type: 'default', value: 'crosstab' } } ,
+      name: { name: [{ type: 'default', value: 'crosstab' }] } ,
       args: s,
       as: {
         type: 'function',
-        name: n,
+        name: { name: [{ type: 'default', value: n }]},
         args: { type: 'expr_list', value: cds.map(v => ({ ...v, type: 'column_definition' })) },
       }
     }
@@ -4475,7 +4475,7 @@ func_call
       z.prefix = 'at time zone'
       return {
         type: 'function',
-        name: { name: { type: 'default', value: name } },
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         suffix: z
       };
@@ -4484,7 +4484,7 @@ func_call
     // => { type: 'function'; name: proc_func_name; args: expr_list; over?: over_partition; }
       return {
         type: 'function',
-        name: { name: { type: 'origin', value: name } },
+        name: { name: [{ type: 'origin', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -4494,7 +4494,7 @@ func_call
     // => { type: 'function'; name: proc_func_name; over?: on_update_current_timestamp; }
     return {
         type: 'function',
-        name: { name: { type: 'origin', value: f } },
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -5218,10 +5218,10 @@ proc_primary
 proc_func_name
   = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
     // => { schema?: ident_without_kw_type, name: ident_without_kw_type }
-      const result = { name: dt }
+      const result = { name: [dt] }
       if (tail !== null) {
         result.schema = dt
-        result.name = tail[3]
+        result.name = [tail[3]]
       }
       return result
     }

--- a/pegjs/redshift.pegjs
+++ b/pegjs/redshift.pegjs
@@ -1918,7 +1918,7 @@ reference_option
     // => { type: 'function'; name: string; args: expr_list; }
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }] },
       args: l
     }
   }
@@ -4435,7 +4435,7 @@ trim_func_clause
     args.value.push(s)
     return {
         type: 'function',
-        name: { name: { type: 'origin', value: 'trim' }},
+        name: { name: [{ type: 'origin', value: 'trim' }]},
         args,
     };
   }
@@ -4445,11 +4445,11 @@ tablefunc_clause
     // => { type: 'tablefunc'; name: proc_func_name; args: expr_list; as: func_call }
     return {
       type: 'tablefunc',
-      name: { name: { type: 'default', value: 'crosstab' } } ,
+      name: { name: [{ type: 'default', value: 'crosstab' }] } ,
       args: s,
       as: {
         type: 'function',
-        name: n,
+        name: { name: [{ type: 'default', value: n }]},
         args: { type: 'expr_list', value: cds.map(v => ({ ...v, type: 'column_definition' })) },
       }
     }
@@ -4462,7 +4462,7 @@ func_call
       z.prefix = 'at time zone'
       return {
         type: 'function',
-        name: { name: { type: 'default', value: name } },
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         suffix: z
       };
@@ -4471,7 +4471,7 @@ func_call
     // => { type: 'function'; name: proc_func_name; args: expr_list; over?: over_partition; }
       return {
         type: 'function',
-        name: { name: { type: 'origin', value: name } },
+        name: { name: [{ type: 'origin', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -4481,7 +4481,7 @@ func_call
     // => { type: 'function'; name: proc_func_name; over?: on_update_current_timestamp; }
     return {
         type: 'function',
-        name: { name: { type: 'origin', value: f } },
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -5206,10 +5206,10 @@ proc_primary
 proc_func_name
   = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
     // => { schema?: ident_without_kw_type, name: ident_without_kw_type }
-      const result = { name: dt }
+      const result = { name: [dt] }
       if (tail !== null) {
         result.schema = dt
-        result.name = tail[3]
+        result.name = [tail[3]]
       }
       return result
     }

--- a/pegjs/snowflake.pegjs
+++ b/pegjs/snowflake.pegjs
@@ -1621,7 +1621,7 @@ reference_option
     // => { type: 'function'; name: string; args: expr_list; }
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }] },
       args: l
     }
   }
@@ -2218,8 +2218,8 @@ column_list_item
     }
   / c:double_quoted_ident __ d:DOT? !{ if(d) return true } __  alias: alias_clause? {
       // => { type: 'expr'; expr: expr; as?: alias_clause; }
-      columnList.add(`select::null::${c}`)
-      return { type: 'expr', expr: { type: 'column_ref', table: null, column: c }, as: alias };
+      columnList.add(`select::null::${c.value}`)
+      return { type: 'expr', expr: { type: 'column_ref', table: null, column: { expr: c } }, as: alias };
   }
   / e:expr_item  __ alias:alias_clause? {
     // => { type: 'expr'; expr: expr; as?: alias_clause; }
@@ -3388,7 +3388,17 @@ column_list
     // => column[]
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
 
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
       // => ident_name
@@ -3410,19 +3420,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { /* => string */ return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { /* => string */ return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { /* => string */ return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 ident_without_kw
   = ident_name / quoted_ident
@@ -3689,7 +3717,7 @@ trim_func_clause
     args.value.push(s)
     return {
         type: 'function',
-        name: 'TRIM',
+        name: { name: [{ type: 'origin', value: 'trim' }]},
         args,
     };
   }
@@ -3757,7 +3785,7 @@ func_call
       z.prefix = 'at time zone'
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         suffix: z
       };
@@ -3765,7 +3793,7 @@ func_call
   / name:'FLATTEN'i __ LPAREN __ l:flattern_args __ RPAREN {
     return {
         type: 'flatten',
-        name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l,
       }
   }
@@ -3773,7 +3801,7 @@ func_call
     // => { type: 'function'; name: string; args: expr_list; over?: over_partition; }
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -3783,7 +3811,7 @@ func_call
     // => { type: 'function'; name: string; over?: on_update_current_timestamp; }
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -4488,13 +4516,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-    // => string
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/pegjs/sqlite.pegjs
+++ b/pegjs/sqlite.pegjs
@@ -903,7 +903,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }] },
       args: l
     }
   }
@@ -1366,7 +1366,7 @@ table_base
       return {
         expr: {
           type: 'function',
-          name: name,
+          name: { name: [{ type: 'default', value: name }]},
           args: l,
         },
         as: alias,
@@ -2002,7 +2002,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
 
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
       return name;
@@ -2022,19 +2032,37 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -2140,7 +2168,7 @@ func_call
   = name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -2148,7 +2176,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -2713,12 +2741,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/pegjs/transactsql.pegjs
+++ b/pegjs/transactsql.pegjs
@@ -1129,7 +1129,7 @@ reference_option
   = kw:KW_CURRENT_TIMESTAMP __ LPAREN __ l:expr_list? __ RPAREN {
     return {
       type: 'function',
-      name: kw,
+      name: { name: [{ type: 'origin', value: kw }]},
       args: l
     }
   }
@@ -2282,7 +2282,17 @@ column_list
   = head:column tail:(__ COMMA __ column)* {
       return createList(head, tail);
     }
+ident_without_kw_type
+  = n:ident_name {
+    return { type: 'default', value: n }
+  }
+  / quoted_ident_type
 
+ident_type
+  = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
+      return { type: 'default', value: name }
+    }
+  / quoted_ident_type
 ident
   = name:ident_name !{ return reservedMap[name.toUpperCase()] === true; } {
       return name;
@@ -2302,23 +2312,45 @@ alias_ident
       return name;
     }
 
+quoted_ident_type
+  = double_quoted_ident / single_quoted_ident / backticks_quoted_ident / brackets_quoted_ident
+
 quoted_ident
-  = double_quoted_ident
-  / single_quoted_ident
-  / backticks_quoted_ident
-  / brackets_quoted_ident
+  = v:(double_quoted_ident / single_quoted_ident / backticks_quoted_ident / brackets_quoted_ident) {
+    return v.value
+  }
 
 double_quoted_ident
-  = '"' chars:[^"]+ '"' { return chars.join(''); }
+  = '"' chars:[^"]+ '"' {
+    return {
+      type: 'double_quote_string',
+      value: chars.join('')
+    }
+  }
 
 single_quoted_ident
-  = "'" chars:[^']+ "'" { return chars.join(''); }
+  = "'" chars:[^']+ "'" {
+    return {
+      type: 'single_quote_string',
+      value: chars.join('')
+    }
+  }
 
 backticks_quoted_ident
-  = "`" chars:[^`]+ "`" { return chars.join(''); }
+  = "`" chars:[^`]+ "`" {
+    return {
+      type: 'backticks_quote_string',
+      value: chars.join('')
+    }
+  }
 
 brackets_quoted_ident
-  = "[" chars:[^\]]+ "]" { return chars.join(''); }
+  = "[" chars:[^\]]+ "]" {
+    return {
+      type: 'brackets_quote_string',
+      value: chars.join('')
+    }
+  }
 
 column_without_kw
   = name:column_name {
@@ -2526,7 +2558,7 @@ func_call
   = name:scalar_func __ LPAREN __ l:expr_list? __ RPAREN __ bc:over_partition? {
       return {
         type: 'function',
-        name: name,
+        name: { name: [{ type: 'default', value: name }] },
         args: l ? l: { type: 'expr_list', value: [] },
         over: bc
       };
@@ -2534,7 +2566,7 @@ func_call
   / f:scalar_time_func __ up:on_update_current_timestamp? {
     return {
         type: 'function',
-        name: f,
+        name: { name: [{ type: 'origin', value: f }] },
         over: up
     }
   }
@@ -3090,12 +3122,13 @@ proc_primary
     }
 
 proc_func_name
-  = dt:ident_name tail:(__ DOT __ ident_name)? {
-      let name = dt
+  = dt:ident_without_kw_type tail:(__ DOT __ ident_without_kw_type)? {
+      const result = { name: [dt] }
       if (tail !== null) {
-        name = `${dt}.${tail[3]}`
+        result.schema = dt
+        result.name = [tail[3]]
       }
-      return name;
+      return result
     }
 
 proc_func_call

--- a/src/column.js
+++ b/src/column.js
@@ -139,6 +139,7 @@ function columnDefinitionToSQL(columnDefinition) {
 
 function asToSQL(asStr) {
   if (!asStr) return ''
+  if (typeof asStr === 'object') return ['AS', exprToSQL(asStr)].join(' ')
   return ['AS', /^(`?)[a-z_][0-9a-z_]*(`?)$/i.test(asStr) ? identifierToSql(asStr) : columnIdentifierToSql(asStr)].join(' ')
 }
 

--- a/src/func.js
+++ b/src/func.js
@@ -71,7 +71,7 @@ function funcToSQL(expr) {
   const collateStr = commonTypeValue(collate).join(' ')
   const overStr = overToSQL(over)
   const suffixStr = exprToSQL(suffix)
-  const funcName = typeof name === 'string' ? name : [name.schema, name.name].map(literalToSQL).filter(hasVal).join('.')
+  const funcName = [literalToSQL(name.schema), name.name.map(literalToSQL).join('.')].filter(hasVal).join('.')
   if (!args) return [funcName, overStr].filter(hasVal).join(' ')
   let separator = expr.separator || ', '
   if (toUpper(funcName) === 'TRIM') separator = ' '
@@ -85,7 +85,7 @@ function funcToSQL(expr) {
 
 function tablefuncFunToSQL(expr) {
   const { as, name, args } = expr
-  const funcName = typeof name === 'string' ? name : [name.schema, name.name].map(literalToSQL).filter(hasVal).join('.')
+  const funcName = [literalToSQL(name.schema), name.name.map(literalToSQL).join('.')].filter(hasVal).join('.')
   const result = [`${funcName}(${exprToSQL(args).join(', ')})`, 'AS', funcToSQL(as)]
   return result.join(' ')
 }

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -117,9 +117,9 @@ describe('Command SQL', () => {
       expect(getParsedSql('call db.sp(12, "test", @firstParameter)'))
         .to.equal('CALL db.sp(12, "test", @firstParameter)')
       expect(getParsedSql('call `db`.`sp`(12, "test", @firstParameter);'))
-        .to.equal('CALL db.sp(12, "test", @firstParameter)')
+        .to.equal('CALL `db`.`sp`(12, "test", @firstParameter)')
       expect(getParsedSql('call `db`.`sp`'))
-        .to.equal('CALL db.sp')
+        .to.equal('CALL `db`.`sp`')
     })
 
   })

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -289,7 +289,7 @@ describe('select', () => {
           {
             expr: {
               type: 'function',
-              name: 'fun',
+              name: { name: [{ type: 'default', value: 'fun' }]},
               over: null,
               args: {
                 type  : 'expr_list',
@@ -319,7 +319,7 @@ describe('select', () => {
           {
             expr: {
               type: 'function',
-              name: 'position',
+              name: { name: [{ type: 'default', value: 'position' }]},
               over: null,
               args: {
                 type: 'expr_list',
@@ -352,7 +352,7 @@ describe('select', () => {
           {
             expr: {
               type: 'function',
-              name: func,
+              name: { name: [{ type: 'default', value: func }]},
               over: null,
               args: {
                 type: 'expr_list',
@@ -741,7 +741,7 @@ describe('select', () => {
       expect(ast.limit).to.be.null;
     })
 
-    it('should support left and covert fun', () => {
+    it('should support left and convert fun', () => {
       expect(getParsedSql(`select * from test where LEFT(column,2)="ts";`))
         .to.equal('SELECT * FROM `test` WHERE LEFT(`column`, 2) = "ts"')
       expect(getParsedSql(`select * from test where CONVERT(column, DATE)="test";`))

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -69,7 +69,7 @@ describe('update', () => {
           table: null,
           value: {
             type: "function",
-            name: "concat",
+            name: { name: [{ type: 'default', value: 'concat' }]},
             over: null,
             args: {
               type: "expr_list",


### PR DESCRIPTION
- change function name from string type to object, keep original quoted symbol