### PR TITLE
refactor: new function name types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -73,7 +73,7 @@ export interface AggrFunc {
 export type FunctionName = { schema?: string, name: ValueExpr<string>[] }
 export interface Function {
   type: "function";
-  name: { name: FunctionName[] };
+  name: FunctionName;
   args: ExprList;
   suffix?: any;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -39,10 +39,16 @@ export interface OrderBy {
   type: "ASC" | "DESC";
   expr: any;
 }
+
+export interface ValueExpr<T = string | number | boolean> {
+  type: "backticks_quote_string" | "string" | "regex_string" | "hex_string" | "full_hex_string" | "natural_string" | "bit_string" | "double_quote_string" | "single_quote_string" | "boolean" | "bool" | "null" | "star" | "param" | "origin" | "date" | "datetime" | "time" | "timestamp" | "var_string";
+  value: T;
+}
+
 export interface ColumnRef {
   type: "column_ref";
   table: string | null;
-  column: string;
+  column: string | { expr: ValueExpr };
 }
 export interface SetList {
   column: string;
@@ -65,7 +71,7 @@ export interface AggrFunc {
 }
 export interface Function {
   type: "function";
-  name: string;
+  name: { name: ValueExpr<string>[] };
   args: ExprList;
   suffix?: any;
 }
@@ -81,17 +87,17 @@ type Value = { type: string; value: any };
 
 export type Expr =
   | {
-      type: "binary_expr";
-      operator: "AND" | "OR";
-      left: Expr;
-      right: Expr;
-    }
+    type: "binary_expr";
+    operator: "AND" | "OR";
+    left: Expr;
+    right: Expr;
+  }
   | {
-      type: "binary_expr";
-      operator: string;
-      left: ColumnRef | Param | Value;
-      right: ColumnRef | Param | Value;
-    };
+    type: "binary_expr";
+    operator: string;
+    left: ColumnRef | Param | Value;
+    right: ColumnRef | Param | Value;
+  };
 
 export type ExprList = {
   type: "expr_list";

--- a/types.d.ts
+++ b/types.d.ts
@@ -69,9 +69,11 @@ export interface AggrFunc {
   name: string;
   args: ColumnRef | AggrFunc | Star | null;
 }
+
+export type FunctionName = ValueExpr<string> & { schema?: string }
 export interface Function {
   type: "function";
-  name: { name: ValueExpr<string>[] };
+  name: { name: FunctionName[] };
   args: ExprList;
   suffix?: any;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -70,7 +70,7 @@ export interface AggrFunc {
   args: ColumnRef | AggrFunc | Star | null;
 }
 
-export type FunctionName = ValueExpr<string> & { schema?: string }
+export type FunctionName = { schema?: string, name: ValueExpr<string>[] }
 export interface Function {
   type: "function";
   name: { name: FunctionName[] };


### PR DESCRIPTION
This is a re-introduction of  the changes made in https://github.com/taozhi8833998/node-sql-parser/pull/1828
The PR above was made to the upstream [refactor-quoted-func-name](https://github.com/taozhi8833998/node-sql-parser/tree/refactor-quoted-func-name) branch, but the branch was merged to master before https://github.com/taozhi8833998/node-sql-parser/pull/1828 was merged - so the types were not updated in master

I now submitted this PR to master