### PR TITLE
fix: bigquery array brackets and parentheses handling

### DIFF
--- a/pegjs/bigquery.pegjs
+++ b/pegjs/bigquery.pegjs
@@ -2062,15 +2062,24 @@ array_expr
       brackets: true,
     }
   }
-  / s:(array_type / KW_ARRAY)? __ l:(LBRAKE / LPAREN) __ c:(parentheses_list_expr / expr) __ r:(RBRAKE / RPAREN) {
-    if (`${l}${r}` !== '[]' && `${l}${r}` !== '()') throw new Error('parentheses or brackets is not in pair')
+   / s:(array_type / KW_ARRAY)? __ l:(LBRAKE) __ c:(parentheses_list_expr / expr) __ r:(RBRAKE) {
     return {
       definition: s,
       expr_list: c,
       type: 'array',
       keyword: s && 'array',
-      brackets: l === '[' ? true : false,
-      parentheses: l === '(' ? true: false
+      brackets: true,
+      parentheses: false
+    }
+  }
+  / s:(array_type / KW_ARRAY) __ l:(LPAREN) __ c:(parentheses_list_expr / expr) __ r:(RPAREN) {
+    return {
+      definition: s,
+      expr_list: c,
+      type: 'array',
+      keyword: s && 'array',
+      brackets: false,
+      parentheses: true
     }
   }
 

--- a/test/bigquery.spec.js
+++ b/test/bigquery.spec.js
@@ -820,7 +820,7 @@ describe('BigQuery', () => {
       title: 'if multiple parentheses',
       sql: [
         'select if(((a)), b, null)',
-        'SELECT if(((a)), b, NULL)'
+        'SELECT if((a), b, NULL)'
       ]
     },
     {


### PR DESCRIPTION
In BigQuery dialect, everything in parentheses is considered as `type: 'array'`. 
This PR fixes this behavior to distinguish between brackets (`[]`) which are indeed considered as array, and parentheses which require an explicit `array(...)` expression

Fixing this changed the behavior of multiple parentheses expression, when reconstructing the sql from ast. This caused a test to fail, which was added when fixing [this issue](https://github.com/taozhi8833998/node-sql-parser/issues/1661) . We changed the test to accommodate the new behavior. The issue talked about a syntactic error (`((...))` turned to `[(...)]` which is wrong), while the new behavior simply omits the redundant parentheses (`((...))` turning to `(...)` which are syntactically equivalent)