### PR TITLE
Support Column "as" to be ValueExpr

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -172,7 +172,7 @@ export interface Function {
 }
 export interface Column {
   expr: ExpressionValue;
-  as: string | null;
+  as: ValueExpr<string> | string | null;
   type?: string;
   loc?: LocationRange;
 }


### PR DESCRIPTION
In BigQuery and mysql, the alias can be wrapped with backticks and then the as evaluates as ValueExpr<string> with type "backticks_quote_string"