### PR TITLE
Change the type definition of `Cast.expr` from `Expr` to `ExpressionValue`

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -140,7 +140,7 @@ export interface Case {
 export interface Cast {
   type: "cast";
   keyword: "cast";
-  expr: Expr;
+  expr: ExpressionValue;
   symbol: "as";
   target: {
     dataType: string;


### PR DESCRIPTION
It appears that `Expr` represents a binary expression used in a condition, and in the `Cast` node, it seems more appropriate to use `ExpressionValue` instead of `Expr`. 

I dump the AST and found that the `expr` in the `Cast` node is indeed `ExpressionValue` not `Expr`:

```json
"expr": {
    "type": "cast",
    "keyword": "cast",
    "expr": {
        "type": "column_ref",
        "table": null,
        "column": "out_trade_no_"
    },
    "symbol": "as",
    "target": {
        "dataType": "INTEGER",
        "suffix": []
    }
},
```