### PR TITLE
fix: create table as table defintion could be optional in pg

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -832,7 +832,7 @@ create_table_stmt
     KW_TABLE __
     ife:if_not_exists_stmt? __
     t:table_ref_list __
-    c:create_table_definition __
+    c:create_table_definition? __
     to:table_options? __
     ir: (KW_IGNORE / KW_REPLACE)? __
     as:KW_AS? __

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -1638,6 +1638,13 @@ describe('Postgres', () => {
         'START TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY, NOT DEFERRABLE'
       ]
     },
+    {
+      title: 'create table as',
+      sql: [
+        'create table test as select 1',
+        'CREATE TABLE "test" AS SELECT 1'
+      ]
+    },
   ]
   function neatlyNestTestedSQL(sqlList){
     sqlList.forEach(sqlInfo => {


### PR DESCRIPTION
- fix #2086 