### PR TITLE
fix: don't require column expression for alter first

### DIFF
--- a/pegjs/mariadb.pegjs
+++ b/pegjs/mariadb.pegjs
@@ -1027,12 +1027,12 @@ alter_table_stmt
     }
 
 alter_column_suffix
-  = k:('after'i / 'first'i) __ i:column_ref {
-    return {
-      keyword: k,
-      expr: i
+  = k:"first"i {
+      return { keyword: k };
     }
-  }
+  / k:"after"i __ i:column_ref {
+      return { keyword: k, expr: i };
+    }
 
 alter_action_list
   = head:alter_action tail:(__ COMMA __ alter_action)* {

--- a/src/alter.js
+++ b/src/alter.js
@@ -64,7 +64,7 @@ function alterExprToSQL(expr) {
     toUpper(prefix),
     name && name.trim(),
     dataType.filter(hasVal).join(' '),
-    suffix && `${toUpper(suffix.keyword)} ${columnRefToSQL(suffix.expr)}`,
+    suffix && `${toUpper(suffix.keyword)}${suffix.expr ? ` ${columnRefToSQL(suffix.expr)}` : ''}`,
   ]
   return alterArray.filter(hasVal).join(' ')
 }

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -175,8 +175,8 @@ describe('Command SQL', () => {
     it('should change column', () => {
       expect(getParsedSql('alter table places change city city2 varchar(255)'))
         .to.equal('ALTER TABLE `places` CHANGE `city` `city2` VARCHAR(255)');
-      expect(getParsedSql('alter table places change city city2 varchar(255) first city'))
-        .to.equal('ALTER TABLE `places` CHANGE `city` `city2` VARCHAR(255) FIRST `city`');
+      expect(getParsedSql('alter table places change city city2 varchar(255) first'))
+        .to.equal('ALTER TABLE `places` CHANGE `city` `city2` VARCHAR(255) FIRST');
     })
 
     it('should support alter column with algorithm and lock option', () => {

--- a/test/mysql-mariadb.spec.js
+++ b/test/mysql-mariadb.spec.js
@@ -1010,6 +1010,13 @@ describe('mysql', () => {
         ]
       },
       {
+        title: 'alter table with first column',
+        sql: [
+          "ALTER TABLE product MODIFY COLUMN type enum('one','two') NOT NULL FIRST",
+          "ALTER TABLE `product` MODIFY COLUMN `type` ENUM('one', 'two') NOT NULL FIRST"
+        ]
+      },
+      {
         title: 'create table with check constraint',
         sql: [
           'CREATE TABLE `Pattern` (`IsInterpolated` INT NOT NULL, `Value` DOUBLE, CONSTRAINT `CHK_Value_IsInterpolated` CHECK ((`Value` IS NOT NULL) OR (`IsInterpolated` = 0)));',


### PR DESCRIPTION
I'm not sure if you accept contributions, however I've had a go at fixing an issue I reported. As far as I know `FIRST <column>` is not valid in any flavour of SQL, unlike `AFTER <column>`.

resolves #2232 