### PR TITLE
fix: support drop constraint in mysql

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -1428,6 +1428,15 @@ ALTER_DROP_CONSTRAINT
         type: 'alter',
       }
     }
+  / KW_DROP __ kc:'CONSTRAINT'i __ c:ident_name {
+    return {
+      action: 'drop',
+      constraint: c,
+      keyword: kc.toLowerCase(),
+      resource: 'constraint',
+      type: 'alter',
+    }
+  }
 
 ALTER_ENABLE_CONSTRAINT
   = KW_WITH __ 'CHECK'i __ 'CHECK'i __ KW_CONSTRAINT __ c:ident_name {

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -232,7 +232,7 @@ describe('Command SQL', () => {
     })
 
     it(`should support MySQL alter drop check and column`, () => {
-      KEYWORDS.concat(['CHECK ']).forEach(keyword => {
+      KEYWORDS.concat(['CHECK ', 'CONSTRAINT ']).forEach(keyword => {
         expect(getParsedSql(`alter table a drop ${keyword}xxx`))
         .to.equal(`ALTER TABLE \`a\` DROP ${keyword}\`xxx\``);
         expect(getParsedSql(`alter table a drop ${keyword}xxx, drop ${keyword}yyy`))


### PR DESCRIPTION
This PR adds support for `ALTER TABLE foo DROP CONSTRAINT bar` syntax. 

This is supported in MySQL 8.0 onwards (https://dev.mysql.com/doc/refman/8.0/en/alter-table.html)