### PR TITLE
fix(types): add expr to DataType

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -347,6 +347,7 @@ type DataType = {
   scale?: number;
   suffix?: Timezone | (KW_UNSIGNED | KW_ZEROFILL)[];
   array?: "one" | "two";
+  expr?: Expr | ExprList;
 };
 
 type LiteralNotNull = {


### PR DESCRIPTION
Hi there,

For the literal value datatype such as `ENUM('one', 'two')` the parser emits
```json
"definition": {
  "dataType": "ENUM",
  "expr": { "type": "expr_list", value: [...] }
}
```
But DataType in `types.d.ts` file omits `expr` property, so downstream TypeScript code that inspects the AST can’t be typed correctly.

Hope we can fix this