### PR TITLE
fix(types) add order_by to ColumnRefItem

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -347,6 +347,7 @@ type DataType = {
   scale?: number;
   suffix?: Timezone | (KW_UNSIGNED | KW_ZEROFILL)[];
   array?: "one" | "two";
+  expr?: Expr | ExprList;
 };
 
 type LiteralNotNull = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -355,7 +355,7 @@ type LiteralNotNull = {
   value: "not null";
 };
 
-type LiteralNull = { type: "null"; value: null };
+type LiteralNull = { type: "null"; value: null | "null" };
 
 type LiteralNumeric = number | { type: "bigint"; value: string };
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -100,6 +100,8 @@ export interface ValueExpr<T = string | number | boolean> {
   value: T;
 }
 
+export type SortDirection = 'ASC' | 'DESC';
+
 export interface ColumnRefItem {
   type: "column_ref";
   table: string | null;
@@ -107,6 +109,7 @@ export interface ColumnRefItem {
   options?: ExprList;
   loc?: LocationRange;
   collate?: { collate: CollateExpr };
+  order_by?: SortDirection | null;
 }
 export interface ColumnRefExpr {
   type: "expr";


### PR DESCRIPTION
Hi there,

When parsing the SQL statements that define indexes, the AST includes the `order_by` property on ColumnRefItem objects. For example:
```json
"definition": [
  {
    "type": "column_ref",
    "column": "email",
    "order_by": "ASC"
  }
],
```

However the ColumnRefItem interface does not currently include `order_by`, which causes type errors when working with the returned AST.

Thanks for maintaining this repo.