### PR TITLE
fix: improve types for `CREATE INDEX`

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -100,7 +100,7 @@ export interface ValueExpr<T = string | number | boolean> {
   value: T;
 }
 
-export type SortDirection = 'ASC' | 'DESC';
+export type SortDirection = 'ASC' | 'DESC' | 'asc' | 'desc';
 
 export interface ColumnRefItem {
   type: "column_ref";
@@ -480,7 +480,7 @@ export interface Create {
   type: "create";
   keyword: "aggregate" | "table" | "trigger" | "extension" | "function" | "index" | "database" | "schema" | "view" | "domain" | "type" | "user";
   temporary?: "temporary" | null;
-  table?: { db: string; table: string }[];
+  table?: { db: string; table: string }[] | { db: string | null, table: string };
   if_not_exists?: "if not exists" | null;
   like?: {
     type: "like";
@@ -496,9 +496,9 @@ export interface Create {
     keyword: "using";
     type: "btree" | "hash";
   } | null;
-  index?: string | null;
+  index?: string | null | { schema: string | null, name: string};
   on_kw?: "on" | null;
-  index_columns?: any[] | null;
+  index_columns?: ColumnRefItem[] | null;
   index_type?: "unique" | "fulltext" | "spatial" | null;
   index_options?: any[] | null;
   algorithm_option?: {
@@ -517,6 +517,7 @@ export interface Create {
   } | null;
   database?: string;
   loc?: LocationRange;
+  where?: Binary | Function | null
 }
 
 export interface Drop {


### PR DESCRIPTION
This improves the typings a bit, in particular for the `CREATE INDEX` statement. I'm basing this off of the behavior I'm seeing for the following SQL using the SQLite dialect:

```sql
CREATE INDEX person_idx ON persons (name DESC) where name is not null
```

```json
{
  "type": "create",
  "index_type": null,
  "keyword": "index",
  "if_not_exists": null,
  "index": {
    "schema": null,
    "name": "person_idx"
  },
  "on_kw": "on",
  "table": {
    "db": null,
    "table": "persons"
  },
  "index_columns": [
    {
      "collate": null,
      "type": "column_ref",
      "table": null,
      "column": "name",
      "order_by": "desc"
    }
  ],
  "where": {
    "type": "binary_expr",
    "operator": "IS NOT",
    "left": {
      "type": "column_ref",
      "table": null,
      "column": "name",
      "collate": null
    },
    "right": {
      "type": "null",
      "value": null
    }
  }
}

```