### PR TITLE
perf: remove rest spread Babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,8 +13,5 @@
         "debug": false
       }
     ]
-  ],
-  "plugins": [
-    "@babel/plugin-proposal-object-rest-spread"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -82,6 +82,7 @@
     ],
     "max-len": 0,
     "prefer-arrow-callback": 2,
+    "prefer-object-spread": "error",
     "arrow-spacing": [
       2,
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-sql-parser",
-  "version": "5.3.9",
+  "version": "5.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-sql-parser",
-      "version": "5.3.9",
+      "version": "5.3.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/pegjs": "^0.10.0",
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@babel/cli": "^7.5.5",
         "@babel/core": "^7.10.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
         "@babel/preset-env": "^7.10.4",
         "@babel/register": "^7.10.5",
         "@types/chai": "^4.1.7",
@@ -527,26 +526,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -584,18 +563,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -16470,19 +16437,6 @@
         "@babel/traverse": "^7.25.9"
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      }
-    },
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -16506,15 +16460,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.25.9"
-      }
-    },
-    "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-unicode-sets-regex": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.10.5",
-    "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+
     "@babel/preset-env": "^7.10.4",
     "@babel/register": "^7.10.5",
     "@types/chai": "^4.1.7",

--- a/pegjs/snowflake.pegjs
+++ b/pegjs/snowflake.pegjs
@@ -2504,7 +2504,7 @@ table_base
     // => table_name & { as?: alias_clause; }
       if (t.type === 'var') {
         t.as = alias;
-        Object.assign(t, {...getLocationObject()})
+        t = { ...t, ...getLocationObject() }
         return t;
       } else {
         return {

--- a/pegjs/trino.pegjs
+++ b/pegjs/trino.pegjs
@@ -2470,7 +2470,7 @@ table_base
     // => table_name & { as?: alias_clause; }
       if (t.type === 'var') {
         t.as = alias;
-        Object.assign(t, {...getLocationObject()})
+        t = { ...t, ...getLocationObject() }
         return t;
       } else {
         return {


### PR DESCRIPTION
This commit removes `@babel/plugin-proposal-object-rest-spread` since all runtime targets (even the now-ancient Node.js 8) support the spread syntax natively. This should slightly reduce the size of the build.

I've also enabled the ESLint `prefer-object-spread` rule:
https://eslint.org/docs/latest/rules/prefer-object-spread
