### PR TITLE
Retain commas when there are only two args to trim

### DIFF
--- a/src/func.js
+++ b/src/func.js
@@ -105,10 +105,10 @@ function funcToSQL(expr) {
   const funcName = [literalToSQL(name.schema), name.name.map(literalToSQL).join('.')].filter(hasVal).join('.')
   if (!args) return [funcName, withinGroupStr, overStr].filter(hasVal).join(' ')
   let separator = expr.separator || ', '
-  if (toUpper(funcName) === 'TRIM') separator = ' '
   let str = [funcName]
   str.push(args_parentheses === false ? ' ' : '(')
   const argsList = exprToSQL(args)
+  if (toUpper(funcName) === 'TRIM' && argsList.length > 2) separator = ' '
   if (Array.isArray(separator)) {
     let argsSQL = argsList[0]
     for (let i = 1, len = argsList.length; i < len; ++i) {

--- a/test/snowflake.spec.js
+++ b/test/snowflake.spec.js
@@ -546,6 +546,14 @@ describe('snowflake', () => {
         "SELECT split('12-34', '-')[0] FROM DUAL"
       ]
     },
+    {
+      title: 'trim with two parameters',
+      sql: [
+        "SELECT trim(col, ' ') FROM DUAL",
+        "SELECT trim(\"col\", ' ') FROM DUAL",
+      ]
+    },
+
   ]
   SQL_LIST.forEach(sqlInfo => {
     const { title, sql } = sqlInfo


### PR DESCRIPTION
Fixes #2596 