### PR TITLE
support mysql straight_join join_op

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -2696,6 +2696,7 @@ join_op
   / KW_RIGHT __ KW_OUTER? __ KW_JOIN { return 'RIGHT JOIN'; }
   / KW_FULL __ KW_OUTER? __ KW_JOIN { return 'FULL JOIN'; }
   / KW_CROSS __ KW_JOIN { return 'CROSS JOIN'; }
+  / KW_STRAIGHT_JOIN { return 'STRAIGHT_JOIN'; }
   / (KW_INNER __)? KW_JOIN { return 'INNER JOIN'; }
 
 table_name
@@ -4125,6 +4126,7 @@ KW_RIGHT    = "RIGHT"i    !ident_start
 KW_FULL     = "FULL"i     !ident_start
 KW_INNER    = "INNER"i    !ident_start
 KW_CROSS    = "CROSS"i    !ident_start
+KW_STRAIGHT_JOIN = "STRAIGHT_JOIN"i !ident_start
 KW_JOIN     = "JOIN"i     !ident_start
 KW_OUTER    = "OUTER"i    !ident_start
 KW_OVER     = "OVER"i     !ident_start


### PR DESCRIPTION
Adds straight_join support for parsing mysql statements that include straight_join (supported since mysql 5.7 and still through 9.5) https://dev.mysql.com/doc/refman/8.4/en/join.html