### PR TITLE
allow set to include the full grammar

### DIFF
--- a/pegjs/mysql.pegjs
+++ b/pegjs/mysql.pegjs
@@ -4399,7 +4399,7 @@ assign_stmt_list
   }
 
 assign_stmt
-  = va:(var_decl / without_prefix_var_decl) __ s: (KW_ASSIGN / KW_ASSIGIN_EQUAL) __ e:proc_expr {
+  = va:(var_decl / without_prefix_var_decl) __ s: (KW_ASSIGN / KW_ASSIGIN_EQUAL) __ e:expr {
     return {
       type: 'assign',
       left: va,
@@ -4409,7 +4409,7 @@ assign_stmt
   }
 
 select_assign_stmt
-  = va:(var_decl / without_prefix_var_decl) __ s:KW_ASSIGN __ e:proc_expr {
+  = va:(var_decl / without_prefix_var_decl) __ s:KW_ASSIGN __ e:expr {
     return {
       type: 'assign',
       left: va,

--- a/test/cmd.spec.js
+++ b/test/cmd.spec.js
@@ -369,6 +369,11 @@ describe('Command SQL', () => {
         .to.equal(`SET @@${keyword}.id = 123 ; SET @@${keyword}.yy.xx = "abcd"`);
       })
     })
+
+    it('should support set variable with cast', () => {
+      expect(getParsedSql('SET @myvar=CAST("123.1" AS DOUBLE)'))
+        .to.equal('SET @myvar = CAST("123.1" AS DOUBLE)');
+    })
   })
 
   describe('unlock', () => {


### PR DESCRIPTION
Set didn't allow the full grammar like mysql does, so now you can do things like SET @myvar = CAST("123.2" AS DOUBLE), which you could not before.