### PR TITLE
fix: allow cast to type with column alias in postgres

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -5365,15 +5365,13 @@ cast_data_type
   }
 
 cast_double_colon
-  = s:(KW_DOUBLE_COLON __ cast_data_type)+ __ alias:alias_clause? {
+  = s:(KW_DOUBLE_COLON __ cast_data_type)+ {
     /* => {
-        as?: alias_clause,
         symbol: '::' | 'as',
         target: cast_data_type[];
       }
       */
     return {
-      as: alias,
       symbol: '::',
       target: s.map(v => v[2]),
     }

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -1950,6 +1950,13 @@ describe('Postgres', () => {
         'ALTER TABLE "table_name" REPLICA IDENTITY FULL',
       ]
     },
+    {
+      title: 'cast without parentheses and with alias',
+      sql: [
+        'SELECT "createdAt"::date AS created_at, "updatedAt"::date "updated_at", count(*) as "value"',
+        'SELECT "createdAt"::DATE AS "created_at", "updatedAt"::DATE AS "updated_at", COUNT(*) AS "value"'
+      ]
+    },
   ]
   function neatlyNestTestedSQL(sqlList){
     sqlList.forEach(sqlInfo => {


### PR DESCRIPTION
The issue I experienced with the postgresql parser was that the following query did not resolve the column alias for the "createdAt" column which was casted - it resolved to `null`. The `count(*) "value"` did however resolve correctly to its alias.

```sql
select "createdAt"::date as "date",
  count(*) as "value"
  from object_event_log
  group by "createdAt"::date
```

The solution was to remove the `alias:alias_clause?` from the `cast_double_colon` rule, since the alias should be handled at the `column_list_item` level where the cast expression is used.