### PR TITLE
fix(transactsql): restrict FK REFERENCES targets to table names

### DIFF
--- a/pegjs/common/ddl/core.pegjs
+++ b/pegjs/common/ddl/core.pegjs
@@ -384,7 +384,7 @@ create_constraint_foreign
 // Reference definition for foreign keys
 reference_definition
   = kc:KW_REFERENCES __
-  t:table_ref_list __
+  t:referenced_table __
   de:cte_column_definition __
   m:('MATCH FULL'i / 'MATCH PARTIAL'i / 'MATCH SIMPLE'i)? __
   od:on_reference? __
@@ -394,13 +394,18 @@ reference_definition
         table: t,
         keyword: kc.toLowerCase(),
         match: m && m.toLowerCase(),
-        on_action: [od, ou].filter(v => v)
+      on_action: [od, ou].filter(v => v)
       }
   }
   / oa:on_reference {
     return {
       on_action: [oa]
     }
+  }
+
+referenced_table
+  = t:table_name {
+    return [t]
   }
 
 on_reference
@@ -691,4 +696,3 @@ truncate_stmt
         }
       };
     }
-

--- a/pegjs/transactsql.pegjs
+++ b/pegjs/transactsql.pegjs
@@ -1023,7 +1023,7 @@ create_constraint_foreign
 
 reference_definition
   = kc:KW_REFERENCES __
-  t:table_ref_list __
+  t:referenced_table __
   de:cte_column_definition __
   m:('MATCH FULL'i / 'MATCH PARTIAL'i / 'MATCH SIMPLE'i)? __
   od:on_reference? __
@@ -1033,13 +1033,18 @@ reference_definition
         table: t,
         keyword: kc.toLowerCase(),
         match: m && m.toLowerCase(),
-        on_action: [od, ou].filter(v => v)
+      on_action: [od, ou].filter(v => v)
       }
   }
   / oa:on_reference {
     return {
       on_action: [oa]
     }
+  }
+
+referenced_table
+  = t:table_name {
+    return [t]
   }
 
 on_reference

--- a/test/transactsql.spec.js
+++ b/test/transactsql.spec.js
@@ -223,6 +223,14 @@ describe('transactsql', () => {
     expect(getParsedSql(sql)).to.equal(`CREATE TABLE [test] ([id] BIGINT NOT NULL IDENTITY(1, 1), [session_id] INT NOT NULL, PRIMARY KEY CLUSTERED ([id] ASC) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, FILLFACTOR = 90, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]`)
   })
 
+  it('should support foreign key references in create table', () => {
+    const sql = `CREATE TABLE [T] (
+      [Id] INT NOT NULL,
+      CONSTRAINT [FK_T_P] FOREIGN KEY ([Id]) REFERENCES [P] ([Id])
+    )`
+    expect(getParsedSql(sql)).to.equal('CREATE TABLE [T] ([Id] INT NOT NULL, CONSTRAINT [FK_T_P] FOREIGN KEY ([Id]) REFERENCES [P] ([Id]))')
+  })
+
   it('should support alter table', () => {
     const sql = `ALTER TABLE [Class]
     ADD CONSTRAINT [chk_quizId_or_QuizLink]
@@ -231,6 +239,25 @@ describe('transactsql', () => {
         ([quizId] IS NULL AND [QuizLink] IS NOT NULL)
     );`
     expect(getParsedSql(sql)).to.equal(`ALTER TABLE [Class] ADD CONSTRAINT [chk_quizId_or_QuizLink] CHECK (([quizId] IS NOT NULL AND [QuizLink] IS NULL) OR ([quizId] IS NULL AND [QuizLink] IS NOT NULL))`)
+  })
+
+  it('should support foreign key references in alter table', () => {
+    const sql = `ALTER TABLE [ADRABC]
+    ADD CONSTRAINT [FK_ADRABC_ADRESSEN]
+    FOREIGN KEY ([ROWADRESSEN]) REFERENCES [ADRESSEN] ([ROWADRESSEN])
+    ON UPDATE NO ACTION
+    ON DELETE CASCADE`
+    expect(getParsedSql(sql)).to.equal('ALTER TABLE [ADRABC] ADD CONSTRAINT [FK_ADRABC_ADRESSEN] FOREIGN KEY ([ROWADRESSEN]) REFERENCES [ADRESSEN] ([ROWADRESSEN]) ON UPDATE NO ACTION ON DELETE CASCADE')
+  })
+
+  it('should reject aliases in references targets', () => {
+    const sql = 'CREATE TABLE [T] ([Id] INT, FOREIGN KEY ([Id]) REFERENCES [P] AS [Alias] ([Id]))'
+    expect(() => parser.astify(sql, tsqlOpt)).to.throw()
+  })
+
+  it('should reject table hints in references targets', () => {
+    const sql = 'CREATE TABLE [T] ([Id] INT, FOREIGN KEY ([Id]) REFERENCES [P] WITH (NOLOCK) ([Id]))'
+    expect(() => parser.astify(sql, tsqlOpt)).to.throw()
   })
 
   it('should support pviot and unpviot clause', () => {


### PR DESCRIPTION
## Summary

Fix a T-SQL grammar bug in foreign key `REFERENCES` parsing.

## Problem

`reference_definition` used `table_ref_list` for the referenced target. That
pulls in full FROM-clause grammar, which is too permissive for foreign key
references.

As a result:

- valid T-SQL foreign key references could fail to parse
- invalid `REFERENCES` targets with aliases or table hints could be accepted

## Fix

Replace `table_ref_list` with a dedicated `referenced_table` rule that accepts
`table_name` only.

The new rule keeps the existing AST/sqlify shape by returning the referenced
table in the same one-item list form expected downstream.

The fix is applied in:

- `pegjs/transactsql.pegjs`
- `pegjs/common/ddl/core.pegjs`

## Tests

Add T-SQL regression coverage for:

- valid `CREATE TABLE ... FOREIGN KEY ... REFERENCES ...`
- valid `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES ...`
- rejecting aliases in `REFERENCES` targets
- rejecting table hints in `REFERENCES` targets

## Validation

Ran:

- `npm run build:pegjs`
- targeted T-SQL FK regression tests
- full `test/transactsql.spec.js`

All passed after the grammar change.
