### PR TITLE
fix(trino) support "INTERVAL x TO y" data type

### DIFF
--- a/pegjs/trino.pegjs
+++ b/pegjs/trino.pegjs
@@ -4178,6 +4178,12 @@ array_type
     return { ...t, array: { keyword: 'array' } }
   }
 
+interval_type
+  = KW_INTERVAL __ f:interval_unit __ KW_TO __ t:interval_unit {
+    return { dataType: 'INTERVAL ' + f.toUpperCase() + ' TO ' + t.toUpperCase() };
+  }
+  / t:KW_INTERVAL { return { dataType: t }; }
+
 @import 'common/keyword/signedness.pegjs'
 @import 'common/datatype/dialects/trino.pegjs'
 @import 'common/datatype/size.pegjs'
@@ -4191,5 +4197,4 @@ array_type
 @import 'common/datatype/json.pegjs'
 @import 'common/datatype/geometry.pegjs'
 @import 'common/datatype/serial.pegjs'
-@import 'common/datatype/interval.pegjs'
 @import 'common/datatype/uuid.pegjs'

--- a/test/trino.spec.js
+++ b/test/trino.spec.js
@@ -113,6 +113,20 @@ describe('trino', () => {
       title: "DESCRIBE statement with fully qualified name",
       sql: ['DESCRIBE my_catalog.my_schema.my_table', 'DESCRIBE "my_catalog"."my_schema"."my_table"'],
     },
+    {
+      title: 'CAST to INTERVAL DAY TO SECOND',
+      sql: [
+        'SELECT CAST(s.duration AS INTERVAL DAY TO SECOND) FROM t',
+        'SELECT CAST("s".duration AS INTERVAL DAY TO SECOND) FROM "t"',
+      ],
+    },
+    {
+      title: 'CAST to INTERVAL YEAR TO MONTH',
+      sql: [
+        'SELECT CAST(s.age AS INTERVAL YEAR TO MONTH) FROM t',
+        'SELECT CAST("s".age AS INTERVAL YEAR TO MONTH) FROM "t"',
+      ],
+    },
   ];
   SQL_LIST.forEach((sqlInfo) => {
     const { title, sql } = sqlInfo;


### PR DESCRIPTION
Adds support for data types `INTERVAL DAY TO SECOND` and `INTERVAL YEAR TO MONTH`
https://trino.io/docs/current/language/types.html#interval-year-to-month