### PR TITLE
feat(transactsql): support TOP n WITH TIES without parentheses

### DIFF
--- a/pegjs/transactsql.pegjs
+++ b/pegjs/transactsql.pegjs
@@ -1370,18 +1370,22 @@ select_stmt_nake
   }
 
 top_clause
-  = KW_TOP __ LPAREN __ n:number __ RPAREN __ p:('PERCENT'i)? {
-    return {
+  = KW_TOP __ LPAREN __ n:number __ RPAREN __ p:('PERCENT'i)? __ t:with_ties_clause? {
+    const result = {
       value: n,
       percent: p && p.toLowerCase(),
       parentheses: true,
     }
+    if (t) result.with_ties = true
+    return result
   }
-  / KW_TOP __ n:number __ p:('PERCENT'i)? {
-    return {
+  / KW_TOP __ n:number __ p:('PERCENT'i)? __ t:with_ties_clause? {
+    const result = {
       value: n,
       percent: p && p.toLowerCase()
     }
+    if (t) result.with_ties = true
+    return result
   }
 
 // T-SQL: final OPTION (query_hint [, ...]) clause, accepted at the end of
@@ -1412,6 +1416,12 @@ tsql_query_hint
   / 'MAXDOP'i __ v:number                               { return { type: 'query_hint', name: 'MAXDOP', value: v } }
   / 'MAXRECURSION'i __ v:number                         { return { type: 'query_hint', name: 'MAXRECURSION', value: v } }
   / 'FAST'i __ v:number                                 { return { type: 'query_hint', name: 'FAST', value: v } }
+
+// T-SQL: optional WITH TIES modifier for TOP clause.
+// Accepted both with and without parentheses around the TOP expression,
+// e.g. `SELECT TOP (10) WITH TIES ...` and `SELECT TOP 10 WITH TIES ...`.
+with_ties_clause
+  = KW_WITH __ 'TIES'i { return true }
 
 // MySQL extensions to standard SQL
 option_clause

--- a/src/util.js
+++ b/src/util.js
@@ -121,11 +121,12 @@ function setParserOpt(opt) {
 
 function topToSQL(opt) {
   if (!opt) return
-  const { value, percent, parentheses } = opt
+  const { value, percent, parentheses, with_ties: withTies } = opt
   const val = parentheses ? `(${value})` : value
-  const prefix = `TOP ${val}`
-  if (!percent) return prefix
-  return `${prefix} ${percent.toUpperCase()}`
+  const segments = [`TOP ${val}`]
+  if (percent) segments.push(percent.toUpperCase())
+  if (withTies) segments.push('WITH TIES')
+  return segments.join(' ')
 }
 
 function columnIdentifierToSql(ident) {

--- a/test/transactsql.spec.js
+++ b/test/transactsql.spec.js
@@ -71,6 +71,15 @@ describe('transactsql', () => {
     expect(getParsedSql(sql)).to.equal('SELECT [col] FROM [myTable] OPTION (RECOMPILE, MAXDOP 2)')
   })
 
+  it('should support select top n with ties', () => {
+    let sql = 'SELECT TOP 10 WITH TIES col FROM myTable ORDER BY col'
+    expect(getParsedSql(sql)).to.equal('SELECT TOP 10 WITH TIES [col] FROM [myTable] ORDER BY [col] ASC')
+    sql = 'SELECT TOP (10) WITH TIES col FROM myTable ORDER BY col'
+    expect(getParsedSql(sql)).to.equal('SELECT TOP (10) WITH TIES [col] FROM [myTable] ORDER BY [col] ASC')
+    sql = 'SELECT TOP 5 PERCENT WITH TIES col FROM myTable ORDER BY col'
+    expect(getParsedSql(sql)).to.equal('SELECT TOP 5 PERCENT WITH TIES [col] FROM [myTable] ORDER BY [col] ASC')
+  })
+
   it('should support select count', () => {
     let sql = 'select count(*);'
     expect(getParsedSql(sql)).to.equal('SELECT COUNT(*)')


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                            
  SQL Server accepts `TOP n WITH TIES` as a shorthand for `TOP (n) WITH TIES`.
  Previously only the parenthesized form parsed under the `transactsql` dialect.                                                                                                                                            
  This PR extends the grammar to accept both forms, adds an optional `with_ties`
  field to the TOP AST node, and round-trips it back to SQL correctly.                                                                                                                                                      
                                              
  ## Motivation                                                                                                                                                                                                             
                                                                                                                                                                                                                            
  Downstream AST-based validators and linters using the `transactsql` dialect                                                                                                                                               
  currently have to treat valid T-SQL like `SELECT TOP 10 WITH TIES ...` as a                                                                                                                                               
  parse failure, forcing regex fallbacks for what should be a first-class case.                                                                                                                                             
                                                                                                                                                                                                                            
  Reference: [Microsoft SQL Server `TOP` docs](https://learn.microsoft.com/sql/t-sql/queries/top-transact-sql)
                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                
                                                                                                                                                                                                                            
  - **`pegjs/transactsql.pegjs`** — extended `top_clause` with an optional                                                                                                                                                  
    `with_ties_clause` in both parenthesized and non-parenthesized forms;                                                                                                                                                   
    added a small dedicated rule for clarity.               
  - **`src/util.js`** — refactored `topToSQL` to compose the output as a list                                                                                                                                               
    of segments; emits ` WITH TIES` only when `with_ties` is truthy.
  - **`test/transactsql.spec.js`** — added round-trip tests covering the three                                                                                                                                              
    new variants.                                                                                                                                                                                                           
                                                                                                                                                                                                                            
  ## AST shape                                                                                                                                                                                                              
                                                                                                                                                                                                                            
  The new field is added **only when `WITH TIES` is present**, so the AST shape                                                                                                                                             
  for existing parses is unchanged:                         
                                                                                                                                                                                                                            
  ```js                                                                                                                                                                                                                     
  // SELECT TOP 10 WITH TIES col FROM t ORDER BY col
  {                                                                                                                                                                                                                         
    top: { value: 10, with_ties: true }                     
  }                                                                                                                                                                                                                         
                                                                                                                                                                                                                            
  // SELECT TOP 10 col FROM t ORDER BY col  (unchanged, no with_ties key)
  {                                                                                                                                                                                                                         
    top: { value: 10 }                                      
  }                                                                                                                                                                                                                         
  ```                                                                                                                                                                                                                       
   
  ## Test plan                                                                                                                                                                                                              
                                                            
  - [x] `npm test` — full suite green (1571 tests, 0 failing).
    Baseline before the patch was 1570, so the only delta is the new test case.
  - [x] Round-trip verified against a real SQL Server 2022 instance: all six
    generated queries parsed and executed; the control negative (WITH TIES                                                                                                                                                  
    without ORDER BY) was correctly rejected with `Msg 1062`, confirming the
    server is validating rather than accepting blindly.                                                                                                                                                                     
                                                                                                                                                                                                                            
  ## Backwards compatibility                                                                                                                                                                                                
                                                                                                                                                                                                                            
  - `with_ties` is omitted from the AST when the clause is absent, so consumers                                                                                                                                             
    that compare AST objects by deep equality or `JSON.stringify` see no change                                                                                                                                             
    for existing inputs.                                    
  - `topToSQL` produces identical output for all previously-supported shapes.                                                                                                                                               
                                                            
  ## Scope                                                                                                                                                                                                                  
                                                            
  This PR intentionally handles only `TOP n WITH TIES`. A companion PR for the                                                                                                                                              
  final `OPTION (query_hint, ...)` clause (another common T-SQL construct that
  currently fails to parse) is in preparation and will be opened separately.                                                                                                                                                
