### PR TITLE
Bigquery: Support DISTINCT / ORDER BY / LIMIT inside ARRAY_AGG and STRING_AGG

### DIFF
--- a/pegjs/bigquery.pegjs
+++ b/pegjs/bigquery.pegjs
@@ -2438,9 +2438,29 @@ count_arg
   }
   / d:KW_DISTINCT? __ c:or_and_expr __ or:order_by_clause?  { return { distinct: d, expr: c, orderby: or, ...getLocationObject() }; }
 
+array_agg_arg
+  = d:KW_DISTINCT? __ LPAREN __ c:expr __ RPAREN tail:(__ (KW_AND / KW_OR) __ expr)* __ or:order_by_clause? __ lc:limit_clause? {
+    const len = tail.length
+    let result = c
+    result.parentheses = true
+    for (let i = 0; i < len; ++i) {
+      result = createBinaryExpr(tail[i][1], result, tail[i][3])
+    }
+    return {
+      distinct: d,
+      expr: result,
+      orderby: or,
+      limit: lc,
+      ...getLocationObject()
+    };
+  }
+  / d:KW_DISTINCT? __ c:or_and_expr __ or:order_by_clause? __ lc:limit_clause? {
+    return { distinct: d, expr: c, orderby: or, limit: lc, ...getLocationObject() };
+  }
+
 aggr_array_agg
-  = pre:(ident __ DOT)? __ name:(KW_ARRAY_AGG / KW_STRING_AGG) __ LPAREN __ arg:expr __ RPAREN {
-    // => { type: 'aggr_func'; args:count_arg; name: 'ARRAY_AGG' | 'STRING_AGG';  }
+  = pre:(ident __ DOT)? __ name:(KW_ARRAY_AGG / KW_STRING_AGG) __ LPAREN __ arg:array_agg_arg __ RPAREN {
+    // => { type: 'aggr_func'; args: { distinct?: 'DISTINCT'; expr: expr; orderby?: order_by_clause; limit?: limit_clause }; name: 'ARRAY_AGG' | 'STRING_AGG'; }
       return {
         type: 'aggr_func',
         name: pre ? `${pre[0]}.${name}` : name,

--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -1,4 +1,5 @@
 import { exprToSQL, orderOrPartitionByToSQL } from './expr'
+import { limitToSQL } from './limit'
 import { hasVal, literalToSQL, toUpper } from './util'
 import { overToSQL } from './over'
 
@@ -14,6 +15,7 @@ function aggrToSQL(expr) {
   if (args.separator && args.separator.delimiter) str = [str, literalToSQL(args.separator.delimiter)].join(`${args.separator.symbol} `)
   if (args.separator && args.separator.expr) str = [str, exprToSQL(args.separator.expr)].join(' ')
   if (args.orderby) str = [str, orderOrPartitionByToSQL(args.orderby, 'order by')].join(' ')
+  if (args.limit) str = [str, limitToSQL(args.limit)].join(' ')
   if (args.separator && args.separator.value) str = [str, toUpper(args.separator.keyword), literalToSQL(args.separator.value)].filter(hasVal).join(' ')
   const withinGroup = within_group_orderby ? `WITHIN GROUP (${orderOrPartitionByToSQL(within_group_orderby, 'order by')})` : ''
   const filterStr = filter ? `FILTER (WHERE ${exprToSQL(filter.where)})` : ''

--- a/test/bigquery.spec.js
+++ b/test/bigquery.spec.js
@@ -817,6 +817,48 @@ describe('BigQuery', () => {
       ]
     },
     {
+      title: 'ARRAY_AGG DISTINCT modifier',
+      sql: [
+        'SELECT ARRAY_AGG(DISTINCT x) AS a FROM t',
+        'SELECT ARRAY_AGG(DISTINCT x) AS a FROM t',
+      ]
+    },
+    {
+      title: 'ARRAY_AGG LIMIT modifier',
+      sql: [
+        'SELECT ARRAY_AGG(x LIMIT 5) AS a FROM t',
+        'SELECT ARRAY_AGG(x LIMIT 5) AS a FROM t',
+      ]
+    },
+    {
+      title: 'ARRAY_AGG ORDER BY modifier',
+      sql: [
+        'SELECT ARRAY_AGG(x ORDER BY y) AS a FROM t',
+        'SELECT ARRAY_AGG(x ORDER BY y ASC) AS a FROM t',
+      ]
+    },
+    {
+      title: 'ARRAY_AGG DISTINCT ORDER BY LIMIT combined',
+      sql: [
+        'SELECT ARRAY_AGG(DISTINCT x ORDER BY x LIMIT 5) AS a FROM t',
+        'SELECT ARRAY_AGG(DISTINCT x ORDER BY x ASC LIMIT 5) AS a FROM t',
+      ]
+    },
+    {
+      title: 'STRING_AGG LIMIT modifier',
+      sql: [
+        'SELECT STRING_AGG(x LIMIT 3) AS a FROM t',
+        'SELECT STRING_AGG(x LIMIT 3) AS a FROM t',
+      ]
+    },
+    {
+      title: 'STRING_AGG DISTINCT ORDER BY combined',
+      sql: [
+        'SELECT STRING_AGG(DISTINCT x ORDER BY x) AS a FROM t',
+        'SELECT STRING_AGG(DISTINCT x ORDER BY x ASC) AS a FROM t',
+      ]
+    },
+    {
       title: 'if multiple parentheses',
       sql: [
         'select if(((a)), b, null)',
@@ -940,7 +982,7 @@ describe('BigQuery', () => {
         JOIN thingie10 tc ON pt.thingie2 = tc.thingie2
         ORDER BY pt.thingie9 DESC
         LIMIT 20`,
-        "WITH thingie AS (SELECT thingie2, thingie3, COUNT(*) AS thingie4 FROM thingie5.thingie6 WHERE thingie7 BETWEEN '2025-10-24' AND '2025-10-30' AND thingie8 = TRUE AND thingie2 IS NOT NULL GROUP BY thingie2, thingie3), path_totals AS (SELECT thingie2, SUM(thingie4) AS thingie9 FROM thingie GROUP BY thingie2), thingie13 AS (SELECT SUM(thingie9) AS overall_total FROM path_totals), thingie10 AS (SELECT thingie2, ARRAY_AGG(undefined) AS thingie11 FROM thingie GROUP BY thingie2) SELECT pt.thingie2, pt.thingie9 AS thingie4, ROUND(100.0 * pt.thingie9 / tar.overall_total, 2) AS thingie12, tc.thingie11 FROM path_totals AS pt CROSS JOIN thingie13 AS tar JOIN thingie10 AS tc ON pt.thingie2 = tc.thingie2 ORDER BY pt.thingie9 DESC LIMIT 20"
+        "WITH thingie AS (SELECT thingie2, thingie3, COUNT(*) AS thingie4 FROM thingie5.thingie6 WHERE thingie7 BETWEEN '2025-10-24' AND '2025-10-30' AND thingie8 = TRUE AND thingie2 IS NOT NULL GROUP BY thingie2, thingie3), path_totals AS (SELECT thingie2, SUM(thingie4) AS thingie9 FROM thingie GROUP BY thingie2), thingie13 AS (SELECT SUM(thingie9) AS overall_total FROM path_totals), thingie10 AS (SELECT thingie2, ARRAY_AGG(STRUCT(thingie3, thingie4)LIMIT 3) AS thingie11 FROM thingie GROUP BY thingie2) SELECT pt.thingie2, pt.thingie9 AS thingie4, ROUND(100.0 * pt.thingie9 / tar.overall_total, 2) AS thingie12, tc.thingie11 FROM path_totals AS pt CROSS JOIN thingie13 AS tar JOIN thingie10 AS tc ON pt.thingie2 = tc.thingie2 ORDER BY pt.thingie9 DESC LIMIT 20"
       ]
     },
   ]
@@ -949,6 +991,57 @@ describe('BigQuery', () => {
     const { title, sql } = sqlInfo
     it(`should support ${title}`, () => {
       expect(getParsedSql(sql[0], opt)).to.equal(sql[1])
+    })
+  })
+
+  describe('ARRAY_AGG / STRING_AGG aggregate modifiers', () => {
+    function getAggrArgs(sql) {
+      const ast = parser.astify(sql, opt)
+      return ast.columns[0].expr.args
+    }
+
+    it('ARRAY_AGG(DISTINCT x) sets distinct on args', () => {
+      const args = getAggrArgs('SELECT ARRAY_AGG(DISTINCT x) AS a FROM t')
+      expect(args.distinct).to.equal('DISTINCT')
+      expect(args.expr.type).to.equal('column_ref')
+      expect(args.orderby).to.be.null
+      expect(args.limit).to.be.null
+    })
+
+    it('ARRAY_AGG(x LIMIT n) sets limit on args', () => {
+      const args = getAggrArgs('SELECT ARRAY_AGG(x LIMIT 5) AS a FROM t')
+      expect(args.distinct).to.be.null
+      expect(args.expr.type).to.equal('column_ref')
+      expect(args.orderby).to.be.null
+      expect(args.limit.value[0].value).to.equal(5)
+    })
+
+    it('ARRAY_AGG(x ORDER BY y) sets orderby on args', () => {
+      const args = getAggrArgs('SELECT ARRAY_AGG(x ORDER BY y) AS a FROM t')
+      expect(args.distinct).to.be.null
+      expect(args.expr.type).to.equal('column_ref')
+      expect(args.orderby).to.be.an('array').with.lengthOf(1)
+      expect(args.orderby[0].expr.type).to.equal('column_ref')
+      expect(args.limit).to.be.null
+    })
+
+    it('ARRAY_AGG(DISTINCT x ORDER BY x LIMIT n) sets all three', () => {
+      const args = getAggrArgs('SELECT ARRAY_AGG(DISTINCT x ORDER BY x LIMIT 5) AS a FROM t')
+      expect(args.distinct).to.equal('DISTINCT')
+      expect(args.expr.type).to.equal('column_ref')
+      expect(args.orderby).to.be.an('array').with.lengthOf(1)
+      expect(args.limit.value[0].value).to.equal(5)
+    })
+
+    it('STRING_AGG(x LIMIT n) sets limit on args', () => {
+      const args = getAggrArgs('SELECT STRING_AGG(x LIMIT 3) AS a FROM t')
+      expect(args.limit.value[0].value).to.equal(3)
+    })
+
+    it('STRING_AGG(DISTINCT x ORDER BY x) sets distinct and orderby', () => {
+      const args = getAggrArgs('SELECT STRING_AGG(DISTINCT x ORDER BY x) AS a FROM t')
+      expect(args.distinct).to.equal('DISTINCT')
+      expect(args.orderby).to.be.an('array').with.lengthOf(1)
     })
   })
 


### PR DESCRIPTION
## Problem

The BigQuery grammar rejected all three GoogleSQL aggregate modifiers for `ARRAY_AGG` and `STRING_AGG`:

```js
const { Parser } = require('node-sql-parser');
const p = new Parser();
const opt = { database: 'BigQuery' };

p.astify('SELECT ARRAY_AGG(DISTINCT x) AS a FROM t', opt);           // threw
p.astify('SELECT ARRAY_AGG(x LIMIT 5) AS a FROM t', opt);            // threw
p.astify('SELECT ARRAY_AGG(x ORDER BY y) AS a FROM t', opt);         // threw
p.astify('SELECT ARRAY_AGG(DISTINCT x ORDER BY x LIMIT 5) AS a FROM t', opt); // threw
```

These are all valid per the [GoogleSQL `ARRAY_AGG` docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#array_agg):
```
ARRAY_AGG([DISTINCT] expr [ORDER BY key [ASC|DESC] [, ...]] [LIMIT n])
```

## Root cause

`aggr_array_agg` in `pegjs/bigquery.pegjs` matched the argument as a bare `expr`. Any modifier before the closing `)` left unconsumed tokens and caused a parse error.

## Fix

**One rule change** in `pegjs/bigquery.pegjs`: added an `array_agg_arg` rule that accepts the full modifier syntax, then wired `aggr_array_agg` to use it.

The new rule:
- **Reuses** existing building blocks — `count_arg`'s `KW_DISTINCT? / or_and_expr / order_by_clause?` pattern is already tested and correct
- **Mirrors** the PostgreSQL `distinct_args` precedent already in `pegjs/postgresql.pegjs`  
- **Adds** `limit_clause?` as the BigQuery-specific piece (LIMIT inside an aggregate is GoogleSQL-only)
- Returns `{ distinct, expr, orderby, limit }` — same shape as `count_arg`, so `aggrToSQL` needs only one new line

`src/aggregation.js` gains one line: `if (args.limit) str = [str, limitToSQL(args.limit)].join(' ')`.

## Tests

Added to `test/bigquery.spec.js`:
- 6 round-trip tests (one per modifier combination for both `ARRAY_AGG` and `STRING_AGG`)
- 6 AST-shape tests asserting `args.distinct`, `args.orderby`, and `args.limit` are populated correctly
- Updated 1 pre-existing "struct expr" test expectation from `ARRAY_AGG(undefined)` (args were unreachable before) to the now-correctly-parsed output

**Full suite: 1584 passing, 1 pending, 0 regressions.**