### PR TITLE
fix(postgresql): support string concatenation in LIKE/regex right-hand side

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -4505,8 +4505,8 @@ regex_op
   = "!~*" / "~*" / "~" / "!~"
 
 regex_op_right
-= op:regex_op __ right:(literal / comparison_expr) {
-     // => { op: regex_op; right: literal | comparison_expr}
+= op:regex_op __ right:(additive_expr / literal / comparison_expr) {
+     // => { op: regex_op; right: additive_expr | literal | comparison_expr}
       return { op: op, right: right };
     }
 
@@ -4524,8 +4524,8 @@ in_op
   / KW_IN
 
 like_op_right
-  = op:like_op __ right:(literal / comparison_expr) __ es:escape_op? {
-     // => { op: like_op; right: (literal | comparison_expr) & { escape?: escape_op }; }
+  = op:like_op __ right:(additive_expr / literal / comparison_expr) __ es:escape_op? {
+     // => { op: like_op; right: (additive_expr | literal | comparison_expr) & { escape?: escape_op }; }
       if (es) right.escape = es
       return { op: op, right: right };
     }

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -2072,6 +2072,41 @@ describe('Postgres', () => {
         'CREATE TABLE "test_table" (id INT NOT NULL, vector TSVECTOR)'
       ]
     },
+    {
+      title: 'LIKE with string concatenation starting with a literal',
+      sql: [
+        `SELECT * FROM "MES-TimeStamps" WHERE "Task" LIKE '%' || 'step' || '%'`,
+        `SELECT * FROM "MES-TimeStamps" WHERE "Task" LIKE '%' || 'step' || '%'`
+      ]
+    },
+    {
+      title: 'LIKE with string concatenation starting with a column',
+      sql: [
+        `SELECT * FROM "t" WHERE "Task" LIKE prefix || '%'`,
+        `SELECT * FROM "t" WHERE "Task" LIKE prefix || '%'`
+      ]
+    },
+    {
+      title: 'NOT LIKE with string concatenation',
+      sql: [
+        `SELECT * FROM "t" WHERE "Task" NOT LIKE '%' || 'x'`,
+        `SELECT * FROM "t" WHERE "Task" NOT LIKE '%' || 'x'`
+      ]
+    },
+    {
+      title: 'LIKE concatenation with ESCAPE clause',
+      sql: [
+        `SELECT * FROM "t" WHERE "Task" LIKE '%' || 'x' || '%' ESCAPE '!'`,
+        `SELECT * FROM "t" WHERE "Task" LIKE '%' || 'x' || '%' ESCAPE '!'`
+      ]
+    },
+    {
+      title: 'regex match with string concatenation starting with a literal',
+      sql: [
+        `SELECT * FROM "t" WHERE "Task" ~ '^' || 'abc'`,
+        `SELECT * FROM "t" WHERE "Task" ~ '^' || 'abc'`
+      ]
+    },
   ]
   function neatlyNestTestedSQL(sqlList){
     sqlList.forEach(sqlInfo => {


### PR DESCRIPTION
Example: `SELECT * FROM Users WHERE email ILIKE '%' || '@example.com`

The right-hand side of LIKE and regex operators used the ordered choice (literal / comparison_expr), so a leading literal matched and committed before the `||` concatenation chain could be parsed, e.g. `col LIKE '%' || 'x' || '%'` failed with "but '|' found".

Reorder the choice to (additive_expr / literal / comparison_expr) so the full expression (which handles `||`) is attempted first. Add round-trip tests for LIKE/NOT LIKE/ESCAPE and regex concatenation.