### PR TITLE
fix(postgresql): support :: casts on parameter/variable placeholders

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -5294,10 +5294,10 @@ cast_expr
       }]
     };
   }
-  / LPAREN __ e:(or_expr / column_ref_array_index / param) __ RPAREN __ c:cast_double_colon?  {
+  / LPAREN __ e:(or_expr / column_ref_array_index / var_decl / param) __ RPAREN __ c:cast_double_colon?  {
     /* => {
         type: 'cast';
-        expr: or_expr | column_ref | param
+        expr: or_expr | column_ref | var_decl | param
           | expr;
         keyword: 'cast';
       } & cast_double_colon
@@ -5311,10 +5311,10 @@ cast_expr
       expr: e,
     }
   }
-  / e:(interval_expr / aggr_func / window_func / func_call / column_ref_quoted / literal / case_expr / column_ref_array_index / param) __ c:cast_double_colon? {
+  / e:(interval_expr / aggr_func / window_func / func_call / column_ref_quoted / literal / case_expr / column_ref_array_index / var_decl / param) __ c:cast_double_colon? {
     /* => ({
         type: 'cast';
-        expr: literal | jsonb_expr | aggr_func | func_call | case_expr | interval_expr | column_ref | param
+        expr: literal | jsonb_expr | aggr_func | func_call | case_expr | interval_expr | column_ref | var_decl | param
           | expr;
         keyword: 'cast';
       } & cast_double_colon)

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -2072,6 +2072,37 @@ describe('Postgres', () => {
         'CREATE TABLE "test_table" (id INT NOT NULL, vector TSVECTOR)'
       ]
     },
+    {
+      title: 'cast on dollar parameter placeholder inside a function argument',
+      sql: [
+        `SELECT jsonb_array_elements_text($1::jsonb)`,
+        `SELECT jsonb_array_elements_text($1::JSONB)`
+      ]
+    },
+    {
+      title: 'cast on parameter placeholder in WHERE clause',
+      sql: [
+        `SELECT * FROM "t" WHERE a = $1::jsonb`,
+        `SELECT * FROM "t" WHERE a = $1::JSONB`
+      ]
+    },
+    {
+      title: 'cast on parenthesized parameter placeholder',
+      sql: [
+        `SELECT ($1)::int`,
+        `SELECT $1::INT`
+      ]
+    },
+    {
+      title: 'cast on parameter placeholder with nested function casts in CTE',
+      sql: [
+        `WITH input_deals AS (
+           SELECT (jsonb_array_elements_text($1::jsonb))::int AS deal_no
+         )
+         SELECT * FROM input_deals`,
+        `WITH "input_deals" AS (SELECT (jsonb_array_elements_text($1::JSONB))::INT AS "deal_no") SELECT * FROM "input_deals"`
+      ]
+    },
   ]
   function neatlyNestTestedSQL(sqlList){
     sqlList.forEach(sqlInfo => {


### PR DESCRIPTION
Example: `SELECT * FROM "t" WHERE a = $1::jsonb`

cast_expr did not accept var_decl as a cast operand, so `$1::text` failed in function arguments, WHERE clauses, and other expression positions (it only worked at the top column level). Add var_decl to both the bare and parenthesized cast operand lists.

Add round-trip tests for casts on placeholders in function args, WHERE, parenthesized form, and a nested-cast CTE.