### PR TITLE
fix(postgres): Allow casting to UUID array

### DIFF
--- a/pegjs/postgresql.pegjs
+++ b/pegjs/postgresql.pegjs
@@ -5742,15 +5742,15 @@ data_type
 
 
 array_type
-  = t:(numeric_type / character_string_type / text_type) __ LBRAKE __ RBRAKE __ LBRAKE __ RBRAKE {
+  = t:(numeric_type / character_string_type / text_type / uuid_type) __ LBRAKE __ RBRAKE __ LBRAKE __ RBRAKE {
     /* => data_type */
     return { ...t, array: { dimension: 2 } }
   }
-  / t:(numeric_type / character_string_type / text_type) __ LBRAKE __ l:literal_numeric? __ RBRAKE {
+  / t:(numeric_type / character_string_type / text_type / uuid_type) __ LBRAKE __ l:literal_numeric? __ RBRAKE {
     /* => data_type */
     return { ...t, array: { dimension: 1,  length: [l] } }
   }
-  / t:(numeric_type / character_string_type / text_type) __ KW_ARRAY {
+  / t:(numeric_type / character_string_type / text_type / uuid_type) __ KW_ARRAY {
     /* => data_type */
     return { ...t, array: { keyword: 'array' } }
   }

--- a/test/postgres.spec.js
+++ b/test/postgres.spec.js
@@ -2072,6 +2072,13 @@ describe('Postgres', () => {
         'CREATE TABLE "test_table" (id INT NOT NULL, vector TSVECTOR)'
       ]
     },
+    {
+      title: 'cast to uuid array type',
+      sql: [
+        `SELECT string_to_array('a,b', ',')::uuid[]`,
+        `SELECT string_to_array('a,b', ',')::UUID[]`
+      ]
+    },
   ]
   function neatlyNestTestedSQL(sqlList){
     sqlList.forEach(sqlInfo => {


### PR DESCRIPTION
Casting to arrays does not support UUID (my use-case).